### PR TITLE
feat: add season ratings calculated from episode averages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Setup .NET
       if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
             build-mode: none
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,3 +26,6 @@ jobs:
 
     - name: Check C# style formatting
       run: dotnet format style --verify-no-changes --severity warn --verbosity minimal
+
+    - name: Run tests
+      run: dotnet test tests/Jellyfin.Plugin.ImdbRatings.Tests/ --verbosity minimal

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,7 +37,7 @@ jobs:
         git checkout "pr-${PR_NUMBER}"
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Fetch all history for changelog generation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0  # Fetch all history for changelog generation
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 9.0.x
 

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -17,5 +17,7 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool IncludeSeries { get; set; } = true;
 
+    public bool IncludeSeasonAverages { get; set; } = true;
+
     public bool EnableItemDebugLogging { get; set; } = false;
 }

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -17,7 +17,7 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool IncludeSeries { get; set; } = true;
 
-    public bool IncludeSeasonAverages { get; set; } = true;
+    public bool IncludeSeasonAverages { get; set; } = false;
 
     public bool EnableItemDebugLogging { get; set; } = false;
 }

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -48,8 +48,9 @@
                                 <span>Calculate Season Ratings</span>
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">
-                                When enabled, each season's Community Rating is set to the average of its episode ratings.
-                                Only has effect when "Include TV Series" is turned on.
+                                When enabled, each season's Community Rating is set to the average of eligible
+                                IMDb episode ratings in your library. Episodes without an IMDb rating or below
+                                the minimum votes threshold are excluded. Only has effect when "Include TV Series" is turned on.
                             </div>
                         </div>
 
@@ -70,7 +71,8 @@
                         <p style="margin: 0.5em 0;">
                             This plugin downloads the official IMDb ratings flat file daily and updates the
                             <strong>Community Rating</strong> field on all library items that have an IMDb ID.
-                            When enabled, season ratings are calculated as the average of their episode ratings.
+                            When enabled, season ratings are calculated as the average of eligible
+                            IMDb episode ratings in your library.
                             No other metadata (titles, posters, cast, etc.) is modified.
                         </p>
                         <p style="margin: 0.5em 0;">
@@ -146,7 +148,7 @@
                 document.getElementById('txtMinimumVotes').value = minimumVotes;
                 document.getElementById('chkIncludeMovies').checked = !!getConfigValue(config, 'IncludeMovies', 'includeMovies', true);
                 document.getElementById('chkIncludeSeries').checked = !!getConfigValue(config, 'IncludeSeries', 'includeSeries', true);
-                document.getElementById('chkIncludeSeasonAverages').checked = !!getConfigValue(config, 'IncludeSeasonAverages', 'includeSeasonAverages', true);
+                document.getElementById('chkIncludeSeasonAverages').checked = !!getConfigValue(config, 'IncludeSeasonAverages', 'includeSeasonAverages', false);
                 document.getElementById('chkEnableItemDebugLogging').checked = !!getConfigValue(
                     config,
                     'EnableItemDebugLogging',

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -44,6 +44,17 @@
 
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
+                                <input id="chkIncludeSeasonAverages" type="checkbox" is="emby-checkbox" />
+                                <span>Calculate Season Ratings</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">
+                                When enabled, each season's Community Rating is set to the average of its episode ratings.
+                                Only has effect when "Include TV Series" is turned on.
+                            </div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
                                 <input id="chkEnableItemDebugLogging" type="checkbox" is="emby-checkbox" />
                                 <span>Enable Item Debug Logs</span>
                             </label>
@@ -59,6 +70,7 @@
                         <p style="margin: 0.5em 0;">
                             This plugin downloads the official IMDb ratings flat file daily and updates the
                             <strong>Community Rating</strong> field on all library items that have an IMDb ID.
+                            When enabled, season ratings are calculated as the average of their episode ratings.
                             No other metadata (titles, posters, cast, etc.) is modified.
                         </p>
                         <p style="margin: 0.5em 0;">
@@ -134,6 +146,7 @@
                 document.getElementById('txtMinimumVotes').value = minimumVotes;
                 document.getElementById('chkIncludeMovies').checked = !!getConfigValue(config, 'IncludeMovies', 'includeMovies', true);
                 document.getElementById('chkIncludeSeries').checked = !!getConfigValue(config, 'IncludeSeries', 'includeSeries', true);
+                document.getElementById('chkIncludeSeasonAverages').checked = !!getConfigValue(config, 'IncludeSeasonAverages', 'includeSeasonAverages', true);
                 document.getElementById('chkEnableItemDebugLogging').checked = !!getConfigValue(
                     config,
                     'EnableItemDebugLogging',
@@ -157,6 +170,7 @@
                 setConfigValue(config, 'MinimumVotes', 'minimumVotes', getSanitizedMinimumVotesInput());
                 setConfigValue(config, 'IncludeMovies', 'includeMovies', document.getElementById('chkIncludeMovies').checked);
                 setConfigValue(config, 'IncludeSeries', 'includeSeries', document.getElementById('chkIncludeSeries').checked);
+                setConfigValue(config, 'IncludeSeasonAverages', 'includeSeasonAverages', document.getElementById('chkIncludeSeasonAverages').checked);
                 setConfigValue(
                     config,
                     'EnableItemDebugLogging',

--- a/Providers/SeasonRatingCalculator.cs
+++ b/Providers/SeasonRatingCalculator.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.ImdbRatings.Providers;
+
+public static class SeasonRatingCalculator
+{
+    public static Dictionary<Guid, float> CalculateSeasonAverages(
+        IEnumerable<(Guid SeasonId, string? ImdbId)> episodes,
+        IReadOnlyDictionary<string, (float Rating, int Votes)> ratings,
+        int minimumVotes)
+    {
+        var result = new Dictionary<Guid, float>();
+
+        foreach (var group in episodes.GroupBy(e => e.SeasonId))
+        {
+            float sum = 0;
+            int count = 0;
+
+            foreach (var (_, imdbId) in group)
+            {
+                if (!string.IsNullOrEmpty(imdbId)
+                    && ratings.TryGetValue(imdbId, out var ratingData)
+                    && ratingData.Votes >= minimumVotes)
+                {
+                    sum += ratingData.Rating;
+                    count++;
+                }
+            }
+
+            if (count > 0)
+            {
+                result[group.Key] = MathF.Round(sum / count, 1);
+            }
+        }
+
+        return result;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A Jellyfin plugin that downloads the [IMDb ratings flat file](https://datasets.i
 - Batch processing tuned to finish in well under a minute even for massive libraries
 - Configurable minimum votes threshold (default: 1)
 - Choose which library types to update (Movies, TV Series, or both)
+- Season ratings calculated if enabled automatically as the average of their episode ratings
 - Progress reporting in the Jellyfin task UI
 
 ## Installation
@@ -69,3 +70,4 @@ The daily run time is configured in **Dashboard > Scheduled Tasks**; `3:00 AM` i
 - **Minimum Votes** — skip items with fewer IMDb votes than this (default: 1)
 - **Include Movies** — update movie ratings
 - **Include TV Series** — update series and episode ratings
+- **Calculate Season Ratings** — set each season's rating to the average of its episodes (requires Include TV Series)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A Jellyfin plugin that downloads the [IMDb ratings flat file](https://datasets.i
 - Batch processing tuned to finish in well under a minute even for massive libraries
 - Configurable minimum votes threshold (default: 1)
 - Choose which library types to update (Movies, TV Series, or both)
-- Season ratings calculated if enabled automatically as the average of their episode ratings
+- Season ratings (opt-in) calculated as the average of eligible IMDb episode ratings in your library
 - Progress reporting in the Jellyfin task UI
 
 ## Installation
@@ -70,4 +70,4 @@ The daily run time is configured in **Dashboard > Scheduled Tasks**; `3:00 AM` i
 - **Minimum Votes** — skip items with fewer IMDb votes than this (default: 1)
 - **Include Movies** — update movie ratings
 - **Include TV Series** — update series and episode ratings
-- **Calculate Season Ratings** — set each season's rating to the average of its episodes (requires Include TV Series)
+- **Calculate Season Ratings** — set each season's rating to the average of eligible IMDb episode ratings in your library; episodes without IMDb data or below the votes threshold are excluded (requires Include TV Series, default: off)

--- a/ScheduledTasks/RefreshImdbRatingsTask.cs
+++ b/ScheduledTasks/RefreshImdbRatingsTask.cs
@@ -204,8 +204,8 @@ public class RefreshImdbRatingsTask : IScheduledTask
         int seasonSkippedUnchanged = 0;
         if (config.IncludeSeries && config.IncludeSeasonAverages)
         {
-            // Query episodes with IMDb IDs once and group by season (ParentId) to avoid N+1 queries
-            var episodesBySeason = _libraryManager.GetItemList(new InternalItemsQuery
+            // Query episodes with IMDb IDs once and project to (SeasonId, ImdbId) pairs
+            var episodeData = _libraryManager.GetItemList(new InternalItemsQuery
             {
                 IncludeItemTypes = new[] { BaseItemKind.Episode },
                 HasImdbId = true,
@@ -213,9 +213,11 @@ public class RefreshImdbRatingsTask : IScheduledTask
                 Recursive = true
             })
                 .Where(e => e.ParentId != Guid.Empty)
-                .GroupBy(e => e.ParentId);
+                .Select(e => (SeasonId: e.ParentId, ImdbId: e.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb)));
 
-            // Query all seasons for rating comparison and parent lookup during save
+            var seasonAverages = SeasonRatingCalculator.CalculateSeasonAverages(episodeData, ratings, config.MinimumVotes);
+
+            // Query seasons for rating comparison and parent lookup during save
             var seasonsById = _libraryManager.GetItemList(new InternalItemsQuery
             {
                 IncludeItemTypes = new[] { BaseItemKind.Season },
@@ -223,47 +225,14 @@ public class RefreshImdbRatingsTask : IScheduledTask
                 Recursive = true
             }).ToDictionary(s => s.Id);
 
-            foreach (var group in episodesBySeason)
+            foreach (var (seasonId, avgRating) in seasonAverages)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (!seasonsById.TryGetValue(group.Key, out var season))
+                if (!seasonsById.TryGetValue(seasonId, out var season))
                 {
                     continue;
                 }
-
-                float ratingSum = 0;
-                int ratingCount = 0;
-
-                foreach (var episode in group)
-                {
-                    var episodeImdbId = episode.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb);
-                    if (string.IsNullOrEmpty(episodeImdbId))
-                    {
-                        continue;
-                    }
-
-                    if (!ratings.TryGetValue(episodeImdbId, out var ratingData))
-                    {
-                        continue;
-                    }
-
-                    if (ratingData.Votes < config.MinimumVotes)
-                    {
-                        continue;
-                    }
-
-                    ratingSum += ratingData.Rating;
-                    ratingCount++;
-                }
-
-                if (ratingCount == 0)
-                {
-                    seasonSkippedNoRatings++;
-                    continue;
-                }
-
-                float avgRating = MathF.Round(ratingSum / ratingCount, 1);
 
                 if (season.CommunityRating.HasValue && Math.Abs(season.CommunityRating.Value - avgRating) < 0.01f)
                 {
@@ -274,6 +243,8 @@ public class RefreshImdbRatingsTask : IScheduledTask
                 pendingUpdates.Add((season, season.GetParent(), season.CommunityRating, avgRating));
                 seasonUpdated++;
             }
+
+            seasonSkippedNoRatings = seasonsById.Keys.Count(id => !seasonAverages.ContainsKey(id));
 
             _logger.LogInformation(
                 "Season ratings: {Updated} to update, {SkippedUnchanged} unchanged, {SkippedNoRatings} skipped (no eligible episodes)",

--- a/ScheduledTasks/RefreshImdbRatingsTask.cs
+++ b/ScheduledTasks/RefreshImdbRatingsTask.cs
@@ -198,61 +198,63 @@ public class RefreshImdbRatingsTask : IScheduledTask
             }
         }
 
-        // Step 4b: Calculate season ratings as the average of their episode ratings
+        // Step 4b: Calculate season ratings as the average of eligible IMDb episode ratings
         int seasonUpdated = 0;
         int seasonSkippedNoRatings = 0;
         int seasonSkippedUnchanged = 0;
         if (config.IncludeSeries && config.IncludeSeasonAverages)
         {
-            // Build a lookup of effective episode ratings: pending new value takes priority, then existing CommunityRating
-            var effectiveEpisodeRatings = new Dictionary<Guid, float>();
-            foreach (var (item, _, _, newRating) in pendingUpdates)
+            // Query episodes with IMDb IDs once and group by season (ParentId) to avoid N+1 queries
+            var episodesBySeason = _libraryManager.GetItemList(new InternalItemsQuery
             {
-                effectiveEpisodeRatings[item.Id] = newRating;
-            }
+                IncludeItemTypes = new[] { BaseItemKind.Episode },
+                HasImdbId = true,
+                IsVirtualItem = false,
+                Recursive = true
+            })
+                .Where(e => e.ParentId != Guid.Empty)
+                .GroupBy(e => e.ParentId);
 
-            foreach (var item in items)
-            {
-                if (!effectiveEpisodeRatings.ContainsKey(item.Id) && item.CommunityRating.HasValue)
-                {
-                    effectiveEpisodeRatings[item.Id] = item.CommunityRating.Value;
-                }
-            }
-
-            var seasons = _libraryManager.GetItemList(new InternalItemsQuery
+            // Query all seasons for rating comparison and parent lookup during save
+            var seasonsById = _libraryManager.GetItemList(new InternalItemsQuery
             {
                 IncludeItemTypes = new[] { BaseItemKind.Season },
                 IsVirtualItem = false,
                 Recursive = true
-            });
+            }).ToDictionary(s => s.Id);
 
-            foreach (var season in seasons)
+            foreach (var group in episodesBySeason)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var episodes = _libraryManager.GetItemList(new InternalItemsQuery
+                if (!seasonsById.TryGetValue(group.Key, out var season))
                 {
-                    ParentId = season.Id,
-                    IncludeItemTypes = new[] { BaseItemKind.Episode },
-                    IsVirtualItem = false,
-                    Recursive = true
-                });
+                    continue;
+                }
 
                 float ratingSum = 0;
                 int ratingCount = 0;
 
-                foreach (var episode in episodes)
+                foreach (var episode in group)
                 {
-                    if (effectiveEpisodeRatings.TryGetValue(episode.Id, out var rating))
+                    var episodeImdbId = episode.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb);
+                    if (string.IsNullOrEmpty(episodeImdbId))
                     {
-                        ratingSum += rating;
-                        ratingCount++;
+                        continue;
                     }
-                    else if (episode.CommunityRating.HasValue)
+
+                    if (!ratings.TryGetValue(episodeImdbId, out var ratingData))
                     {
-                        ratingSum += episode.CommunityRating.Value;
-                        ratingCount++;
+                        continue;
                     }
+
+                    if (ratingData.Votes < config.MinimumVotes)
+                    {
+                        continue;
+                    }
+
+                    ratingSum += ratingData.Rating;
+                    ratingCount++;
                 }
 
                 if (ratingCount == 0)
@@ -263,7 +265,7 @@ public class RefreshImdbRatingsTask : IScheduledTask
 
                 float avgRating = MathF.Round(ratingSum / ratingCount, 1);
 
-                if (season.CommunityRating.HasValue && MathF.Abs(season.CommunityRating.Value - avgRating) < 0.01f)
+                if (season.CommunityRating.HasValue && Math.Abs(season.CommunityRating.Value - avgRating) < 0.01f)
                 {
                     seasonSkippedUnchanged++;
                     continue;
@@ -274,7 +276,7 @@ public class RefreshImdbRatingsTask : IScheduledTask
             }
 
             _logger.LogInformation(
-                "Season ratings: {Updated} to update, {SkippedUnchanged} unchanged, {SkippedNoRatings} skipped (no rated episodes)",
+                "Season ratings: {Updated} to update, {SkippedUnchanged} unchanged, {SkippedNoRatings} skipped (no eligible episodes)",
                 seasonUpdated, seasonSkippedUnchanged, seasonSkippedNoRatings);
         }
 

--- a/ScheduledTasks/RefreshImdbRatingsTask.cs
+++ b/ScheduledTasks/RefreshImdbRatingsTask.cs
@@ -204,16 +204,13 @@ public class RefreshImdbRatingsTask : IScheduledTask
         int seasonSkippedUnchanged = 0;
         if (config.IncludeSeries && config.IncludeSeasonAverages)
         {
-            // Query episodes with IMDb IDs once and project to (SeasonId, ImdbId) pairs
-            var episodeData = _libraryManager.GetItemList(new InternalItemsQuery
-            {
-                IncludeItemTypes = new[] { BaseItemKind.Episode },
-                HasImdbId = true,
-                IsVirtualItem = false,
-                Recursive = true
-            })
-                .Where(e => e.ParentId != Guid.Empty)
-                .Select(e => (SeasonId: e.ParentId, ImdbId: e.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb)));
+            // Reuse the already-fetched episode results and group by Jellyfin's logical season ID.
+            var episodeData = items
+                .OfType<MediaBrowser.Controller.Entities.TV.Episode>()
+                .Where(e => e.SeasonId != Guid.Empty)
+                .Select(e => (
+                    SeasonId: e.SeasonId,
+                    ImdbId: e.GetProviderId(MediaBrowser.Model.Entities.MetadataProvider.Imdb)));
 
             var seasonAverages = SeasonRatingCalculator.CalculateSeasonAverages(episodeData, ratings, config.MinimumVotes);
 

--- a/ScheduledTasks/RefreshImdbRatingsTask.cs
+++ b/ScheduledTasks/RefreshImdbRatingsTask.cs
@@ -62,8 +62,8 @@ public class RefreshImdbRatingsTask : IScheduledTask
     {
         var config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
 
-        _logger.LogInformation("Starting IMDb ratings refresh (minVotes={MinVotes}, movies={Movies}, series={Series})",
-            config.MinimumVotes, config.IncludeMovies, config.IncludeSeries);
+        _logger.LogInformation("Starting IMDb ratings refresh (minVotes={MinVotes}, movies={Movies}, series={Series}, seasonAverages={SeasonAverages})",
+            config.MinimumVotes, config.IncludeMovies, config.IncludeSeries, config.IncludeSeasonAverages);
 
         // Step 1: Query library items and build a distinct IMDb ID filter set.
         progress.Report(0);
@@ -198,6 +198,86 @@ public class RefreshImdbRatingsTask : IScheduledTask
             }
         }
 
+        // Step 4b: Calculate season ratings as the average of their episode ratings
+        int seasonUpdated = 0;
+        int seasonSkippedNoRatings = 0;
+        int seasonSkippedUnchanged = 0;
+        if (config.IncludeSeries && config.IncludeSeasonAverages)
+        {
+            // Build a lookup of effective episode ratings: pending new value takes priority, then existing CommunityRating
+            var effectiveEpisodeRatings = new Dictionary<Guid, float>();
+            foreach (var (item, _, _, newRating) in pendingUpdates)
+            {
+                effectiveEpisodeRatings[item.Id] = newRating;
+            }
+
+            foreach (var item in items)
+            {
+                if (!effectiveEpisodeRatings.ContainsKey(item.Id) && item.CommunityRating.HasValue)
+                {
+                    effectiveEpisodeRatings[item.Id] = item.CommunityRating.Value;
+                }
+            }
+
+            var seasons = _libraryManager.GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = new[] { BaseItemKind.Season },
+                IsVirtualItem = false,
+                Recursive = true
+            });
+
+            foreach (var season in seasons)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var episodes = _libraryManager.GetItemList(new InternalItemsQuery
+                {
+                    ParentId = season.Id,
+                    IncludeItemTypes = new[] { BaseItemKind.Episode },
+                    IsVirtualItem = false,
+                    Recursive = true
+                });
+
+                float ratingSum = 0;
+                int ratingCount = 0;
+
+                foreach (var episode in episodes)
+                {
+                    if (effectiveEpisodeRatings.TryGetValue(episode.Id, out var rating))
+                    {
+                        ratingSum += rating;
+                        ratingCount++;
+                    }
+                    else if (episode.CommunityRating.HasValue)
+                    {
+                        ratingSum += episode.CommunityRating.Value;
+                        ratingCount++;
+                    }
+                }
+
+                if (ratingCount == 0)
+                {
+                    seasonSkippedNoRatings++;
+                    continue;
+                }
+
+                float avgRating = MathF.Round(ratingSum / ratingCount, 1);
+
+                if (season.CommunityRating.HasValue && MathF.Abs(season.CommunityRating.Value - avgRating) < 0.01f)
+                {
+                    seasonSkippedUnchanged++;
+                    continue;
+                }
+
+                pendingUpdates.Add((season, season.GetParent(), season.CommunityRating, avgRating));
+                seasonUpdated++;
+            }
+
+            _logger.LogInformation(
+                "Season ratings: {Updated} to update, {SkippedUnchanged} unchanged, {SkippedNoRatings} skipped (no rated episodes)",
+                seasonUpdated, seasonSkippedUnchanged, seasonSkippedNoRatings);
+        }
+
         progress.Report(90);
 
         // Step 5: Apply ratings and batch save, grouped by parent and chunked
@@ -281,8 +361,9 @@ public class RefreshImdbRatingsTask : IScheduledTask
         progress.Report(100);
         var skippedTotal = skippedMissingImdbId + skippedBelowMinimumVotes + skippedUnchanged;
         _logger.LogInformation(
-            "IMDb ratings refresh complete: {Updated} updated, {Skipped} skipped ({Unchanged} unchanged, {BelowMinimum} below minimum votes, {MissingImdbId} missing IMDb ID), {NotFound} not found in IMDb ratings",
+            "IMDb ratings refresh complete: {Updated} updated ({SeasonUpdated} seasons from episode averages), {Skipped} skipped ({Unchanged} unchanged, {BelowMinimum} below minimum votes, {MissingImdbId} missing IMDb ID), {NotFound} not found in IMDb ratings",
             pendingUpdates.Count,
+            seasonUpdated,
             skippedTotal,
             skippedUnchanged,
             skippedBelowMinimumVotes,

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/Jellyfin.Plugin.ImdbRatings.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/Jellyfin.Plugin.ImdbRatings.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/Jellyfin.Plugin.ImdbRatings.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/Jellyfin.Plugin.ImdbRatings.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/SeasonRatingCalculatorTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/SeasonRatingCalculatorTests.cs
@@ -315,14 +315,14 @@ public class SeasonRatingCalculatorTests
         {
             ["tt0000001"] = (7.0f, 1000),
             ["tt0000002"] = (7.0f, 1000),
-            ["tt0000003"] = (8.0f, 1000),
-            ["tt0000004"] = (9.0f, 1000),
+            ["tt0000003"] = (7.0f, 1000),
+            ["tt0000004"] = (8.0f, 1000),
         };
 
         var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
 
-        // (7+7+8+9)/4 = 7.75 → banker's rounding → 7.8
-        Assert.Equal(7.8f, result[seasonId]);
+        // (7+7+7+8)/4 = 7.25 → banker's rounding → 7.2
+        Assert.Equal(7.2f, result[seasonId]);
     }
 
     [Fact]

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/SeasonRatingCalculatorTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/SeasonRatingCalculatorTests.cs
@@ -1,0 +1,374 @@
+using Jellyfin.Plugin.ImdbRatings.Configuration;
+using Jellyfin.Plugin.ImdbRatings.Providers;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+public class SeasonRatingCalculatorTests
+{
+    [Fact]
+    public void CalculateSeasonAverages_BasicAverage_ReturnsCorrectValue()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+            (seasonId, "tt0000003"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (8.0f, 2000),
+            ["tt0000003"] = (9.0f, 3000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Single(result);
+        Assert.Equal(8.0f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_ExcludesEpisodesWithNullImdbId()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, null),
+            (seasonId, "tt0000002"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (9.0f, 2000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Single(result);
+        Assert.Equal(8.0f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_ExcludesEpisodesWithEmptyImdbId()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, ""),
+            (seasonId, "tt0000002"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (9.0f, 2000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Single(result);
+        Assert.Equal(8.0f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_ExcludesEpisodesNotInRatingsDataset()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt9999999"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.5f, 1000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Single(result);
+        Assert.Equal(7.5f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_ExcludesEpisodesBelowMinimumVotes()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 5000),
+            ["tt0000002"] = (9.0f, 50),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 100);
+
+        Assert.Single(result);
+        Assert.Equal(7.0f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_IncludesEpisodeAtExactMinimumVotes()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 100),
+            ["tt0000002"] = (9.0f, 100),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 100);
+
+        Assert.Single(result);
+        Assert.Equal(8.0f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_OmitsSeasonWithNoEligibleEpisodes()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, null),
+            (seasonId, "tt9999999"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>();
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_OmitsSeasonWhenAllEpisodesBelowMinimumVotes()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 10),
+            ["tt0000002"] = (9.0f, 20),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 100);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_HandleMultipleSeasons_IndependentAverages()
+    {
+        var season1 = Guid.NewGuid();
+        var season2 = Guid.NewGuid();
+        var season3 = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (season1, "tt0000001"),
+            (season1, "tt0000002"),
+            (season2, "tt0000003"),
+            (season3, "tt0000004"),
+            (season3, null),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (9.0f, 2000),
+            ["tt0000003"] = (6.5f, 500),
+            ["tt0000004"] = (8.0f, 3000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(8.0f, result[season1]);
+        Assert.Equal(6.5f, result[season2]);
+        Assert.Equal(8.0f, result[season3]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_MultipleSeasons_OneWithNoEligibleEpisodes_IsOmitted()
+    {
+        var season1 = Guid.NewGuid();
+        var season2 = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (season1, "tt0000001"),
+            (season1, "tt0000002"),
+            (season2, "tt9999999"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (9.0f, 2000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Single(result);
+        Assert.Equal(8.0f, result[season1]);
+        Assert.False(result.ContainsKey(season2));
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_SingleEpisode_ReturnsEpisodeRating()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (8.5f, 5000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Single(result);
+        Assert.Equal(8.5f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_EmptyInput_ReturnsEmptyResult()
+    {
+        var episodes = Array.Empty<(Guid, string?)>();
+        var ratings = new Dictionary<string, (float Rating, int Votes)>();
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_RoundsDownToOneDecimalPlace()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+            (seasonId, "tt0000003"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (7.0f, 1000),
+            ["tt0000003"] = (8.0f, 1000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        // (7+7+8)/3 = 7.333... → 7.3
+        Assert.Equal(7.3f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_RoundsUpToOneDecimalPlace()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+            (seasonId, "tt0000003"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (8.0f, 1000),
+            ["tt0000003"] = (8.0f, 1000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        // (7+8+8)/3 = 7.666... → 7.7
+        Assert.Equal(7.7f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_MidpointRounding_RoundsToEven()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+            (seasonId, "tt0000003"),
+            (seasonId, "tt0000004"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.0f, 1000),
+            ["tt0000002"] = (7.0f, 1000),
+            ["tt0000003"] = (8.0f, 1000),
+            ["tt0000004"] = (9.0f, 1000),
+        };
+
+        var result = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        // (7+7+8+9)/4 = 7.75 → banker's rounding → 7.8
+        Assert.Equal(7.8f, result[seasonId]);
+    }
+
+    [Fact]
+    public void CalculateSeasonAverages_SameInputTwice_ProducesSameResult()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodes = new (Guid, string?)[]
+        {
+            (seasonId, "tt0000001"),
+            (seasonId, "tt0000002"),
+            (seasonId, "tt0000003"),
+        };
+        var ratings = new Dictionary<string, (float Rating, int Votes)>
+        {
+            ["tt0000001"] = (7.3f, 1000),
+            ["tt0000002"] = (8.7f, 2000),
+            ["tt0000003"] = (6.1f, 500),
+        };
+
+        var result1 = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+        var result2 = SeasonRatingCalculator.CalculateSeasonAverages(episodes, ratings, minimumVotes: 1);
+
+        Assert.Equal(result1[seasonId], result2[seasonId]);
+    }
+
+    [Fact]
+    public void PluginConfiguration_IncludeSeasonAverages_DefaultsFalse()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.False(config.IncludeSeasonAverages);
+    }
+
+    [Fact]
+    public void PluginConfiguration_IncludeSeries_DefaultsTrue()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.True(config.IncludeSeries);
+    }
+
+    [Fact]
+    public void PluginConfiguration_MinimumVotes_DefaultsToOne()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.Equal(1, config.MinimumVotes);
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in automatic season rating calculation. Each season's `CommunityRating` is set to the arithmetic average of eligible episode IMDb ratings from the current downloaded dataset. Only episodes in the local library that meet the configured minimum-votes threshold are included.

IMDb's ratings dataset does not include seasons as standalone entries, so the plugin otherwise leaves seasons without a rating while episodes and series are updated.

This PR also includes the pending GitHub Actions dependency updates from #13 and #16 so all three changes can ship in one release. #12 is intentionally excluded to retain Jellyfin 10.11.8 compatibility.

## Changes

- `PluginConfiguration.cs` — adds `IncludeSeasonAverages`, defaulting to **off**
- `configPage.html` — adds the season-average checkbox and updates descriptions
- `RefreshImdbRatingsTask.cs` — reuses the fetched episodes, groups them by `Episode.SeasonId`, and queues eligible season updates
- `Providers/SeasonRatingCalculator.cs` — extracts the pure averaging helper for testability
- `SeasonRatingCalculatorTests.cs` — adds 19 tests for averaging, filtering, rounding, and configuration defaults
- `Jellyfin.Plugin.ImdbRatings.Tests.csproj` — targets .NET 9, matching the plugin and CI
- `lint.yml` — runs the test suite in CI
- All workflows — update `actions/checkout` from v6 to v7 and `actions/setup-dotnet` from v5 to v6 (#13, #16)
- `README.md` — documents the new opt-in setting

## Validation

- `dotnet build --configuration Release` — succeeds with 0 warnings
- 22/22 tests pass on .NET 9
- Both required `dotnet format` checks pass
- `actionlint` passes
- Author reports testing against a running Jellyfin instance
