### PR TITLE
feat: add cache management to plugin settings page

### DIFF
--- a/Api/CacheController.cs
+++ b/Api/CacheController.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Net.Mime;
+using MediaBrowser.Common.Configuration;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.ImdbRatings.Api;
+
+[ApiController]
+[Route("ImdbRatings/Cache")]
+[Authorize(Policy = "RequiresElevation")]
+[Produces(MediaTypeNames.Application.Json)]
+public class CacheController : ControllerBase
+{
+    private static readonly TimeSpan CacheMaxAge = TimeSpan.FromHours(23);
+
+    private readonly string _cachePath;
+
+    public CacheController(IApplicationPaths applicationPaths)
+    {
+        _cachePath = Path.Join(applicationPaths.DataPath, "imdb-ratings-cache", "title.ratings.tsv");
+    }
+
+    /// <summary>
+    /// Gets the current IMDb ratings cache status.
+    /// </summary>
+    [HttpGet("Status")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<CacheStatusDto> GetStatus()
+    {
+        if (!System.IO.File.Exists(_cachePath))
+        {
+            return Ok(new CacheStatusDto
+            {
+                Exists = false,
+                FileSizeBytes = 0,
+                LastModifiedUtc = null,
+                TtlHours = CacheMaxAge.TotalHours,
+                IsFresh = false
+            });
+        }
+
+        var info = new FileInfo(_cachePath);
+        var lastWrite = info.LastWriteTimeUtc;
+        var age = DateTime.UtcNow - lastWrite;
+
+        return Ok(new CacheStatusDto
+        {
+            Exists = true,
+            FileSizeBytes = info.Length,
+            LastModifiedUtc = lastWrite,
+            TtlHours = CacheMaxAge.TotalHours,
+            IsFresh = age < CacheMaxAge
+        });
+    }
+
+    /// <summary>
+    /// Deletes the cached IMDb ratings file so it will be re-downloaded on next task run.
+    /// </summary>
+    [HttpDelete]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult Delete()
+    {
+        var deleted = false;
+
+        deleted |= TryDeleteFile(_cachePath);
+        deleted |= TryDeleteFile(_cachePath + ".tmp");
+
+        if (!deleted)
+        {
+            return NotFound();
+        }
+
+        return NoContent();
+    }
+
+    private static bool TryDeleteFile(string path)
+    {
+        if (!System.IO.File.Exists(path))
+        {
+            return false;
+        }
+
+        System.IO.File.Delete(path);
+        return true;
+    }
+}

--- a/Api/CacheStatusDto.cs
+++ b/Api/CacheStatusDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Jellyfin.Plugin.ImdbRatings.Api;
+
+public class CacheStatusDto
+{
+    public bool Exists { get; set; }
+
+    public long FileSizeBytes { get; set; }
+
+    public DateTime? LastModifiedUtc { get; set; }
+
+    public double TtlHours { get; set; }
+
+    public bool IsFresh { get; set; }
+}

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -46,51 +46,6 @@
                         </div>
                     </div>
 
-                    <div class="verticalSection">
-                        <h2 class="sectionTitle">IMDb Ratings Cache</h2>
-                        <div id="cacheStatusContainer" style="margin-bottom: 1em;">
-                            <p id="cacheStatus" style="margin: 0;">Loading cache status&hellip;</p>
-                        </div>
-                        <button id="btnDeleteCache" is="emby-button" type="button"
-                                class="raised button-cancel" disabled>
-                            <span>Delete Cache</span>
-                        </button>
-                        <div class="fieldDescription" style="margin-top: 1em;">
-                            Sourced from the
-                            <a href="https://datasets.imdbws.com/title.ratings.tsv.gz" target="_blank" rel="noopener noreferrer">IMDb ratings flat file</a>.
-                            Cached locally to disk with a 23-hour TTL and re-downloaded
-                            automatically when expired.
-                        </div>
-                        <div class="fieldDescription" style="margin-top: 1em;">
-                            Delete the cache to force a fresh download on the next task run.
-                        </div>
-                    </div>
-
-                    <div class="verticalSection">
-                        <h2 class="sectionTitle">Advanced</h2>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label>
-                                <input id="chkIncludeSeasonAverages" type="checkbox" is="emby-checkbox" />
-                                <span>Calculate Season Ratings</span>
-                            </label>
-                            <div class="fieldDescription checkboxFieldDescription">
-                                When enabled, each season's Community Rating is set to the average of eligible
-                                IMDb episode ratings in your library. Episodes without an IMDb rating or below
-                                the minimum votes threshold are excluded. Only has effect when "Include TV Series" is turned on.
-                            </div>
-                        </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription">
-                            <label>
-                                <input id="chkEnableItemDebugLogging" type="checkbox" is="emby-checkbox" />
-                                <span>Enable Item Debug Logs</span>
-                            </label>
-                            <div class="fieldDescription checkboxFieldDescription">
-                                Off by default. When enabled, writes sampled per-item debug logs for troubleshooting
-                                missing IMDb rows and minimum-vote skips (can increase log volume and task duration).
-                            </div>
-                        </div>
-                    </div>
-
                     <div class="verticalSection" style="margin-top: 1em;">
                         <details>
                             <summary style="cursor: pointer; font-weight: 600;">How It Works</summary>
@@ -107,6 +62,54 @@
                             </p>
                         </details>
                     </div>
+
+                    <div class="verticalSection">
+                        <details>
+                            <summary style="cursor: pointer; font-weight: 600;">Advanced Settings</summary>
+                            <div style="margin-top: 1em;">
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label>
+                                        <input id="chkIncludeSeasonAverages" type="checkbox" is="emby-checkbox" />
+                                        <span>Calculate Season Ratings</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">
+                                        When enabled, each season's Community Rating is set to the average of eligible
+                                        IMDb episode ratings in your library. Episodes without an IMDb rating or below
+                                        the minimum votes threshold are excluded. Only has effect when "Include TV Series" is turned on.
+                                    </div>
+                                </div>
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label>
+                                        <input id="chkEnableItemDebugLogging" type="checkbox" is="emby-checkbox" />
+                                        <span>Enable Item Debug Logs</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">
+                                        Off by default. When enabled, writes sampled per-item debug logs for troubleshooting
+                                        missing IMDb rows and minimum-vote skips (can increase log volume and task duration).
+                                    </div>
+                                </div>
+
+                                <h2 class="sectionTitle" style="margin-top: 1.5em; font-size: 1.2em;">IMDb Ratings Cache</h2>
+                                <div id="cacheStatusContainer" style="margin-bottom: 1em;">
+                                    <p id="cacheStatus" style="margin: 0;">Loading cache status&hellip;</p>
+                                </div>
+                                <button id="btnDeleteCache" is="emby-button" type="button"
+                                        class="raised button-cancel" disabled>
+                                    <span>Delete Cache</span>
+                                </button>
+                                <div class="fieldDescription" style="margin-top: 1em;">
+                                    Sourced from the
+                                    <a href="https://datasets.imdbws.com/title.ratings.tsv.gz" target="_blank" rel="noopener noreferrer">IMDb ratings flat file</a>.
+                                    Cached locally to disk with a 23-hour TTL and re-downloaded
+                                    automatically when expired. Delete the cache to force a fresh download on the next task run.
+                                </div>
+                            </div>
+
+
+                        </details>
+                    </div>
+
+                    <hr style="border: 0; border-top: 1px solid rgba(255,255,255,0.1); margin: 1.5em 0;" />
 
                     <div>
                         <button id="btnSave" is="emby-button" type="submit" class="raised button-submit block">

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -8,6 +8,7 @@
          data-require="emby-input,emby-button,emby-checkbox">
         <div data-role="content">
             <div class="content-primary">
+                <h1>IMDb Ratings</h1>
                 <form id="ImdbRatingsConfigForm" onsubmit="return window.ImdbRatingsConfigSubmit(event, this);">
                     <div class="verticalSection">
                         <h2 class="sectionTitle">Filtering</h2>
@@ -16,7 +17,8 @@
                             <input id="txtMinimumVotes" type="number" min="1" max="1000000"
                                    pattern="[0-9]*" required class="emby-input" />
                             <div class="fieldDescription">
-                                Skip items where IMDb has fewer votes than this value (default: 1).
+                                Skip updating items where IMDb has fewer votes than this value. Default: 1.
+                                Lower values can increase task duration because more items qualify for updates.
                             </div>
                         </div>
                     </div>
@@ -72,9 +74,9 @@
                                 <span>Calculate Season Ratings</span>
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">
-                                Set each season's rating to the average of its episode ratings from IMDb.
-                                Episodes without IMDb data or below the votes threshold are excluded.
-                                Requires "Include TV Series".
+                                When enabled, each season's Community Rating is set to the average of eligible
+                                IMDb episode ratings in your library. Episodes without an IMDb rating or below
+                                the minimum votes threshold are excluded. Only has effect when "Include TV Series" is turned on.
                             </div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
@@ -83,8 +85,8 @@
                                 <span>Enable Item Debug Logs</span>
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">
-                                Writes sampled per-item debug logs for troubleshooting missing IMDb rows and
-                                minimum-vote skips. Can increase log volume and task duration.
+                                Off by default. When enabled, writes sampled per-item debug logs for troubleshooting
+                                missing IMDb rows and minimum-vote skips (can increase log volume and task duration).
                             </div>
                         </div>
                     </div>

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -10,18 +10,19 @@
             <div class="content-primary">
                 <form id="ImdbRatingsConfigForm" onsubmit="return window.ImdbRatingsConfigSubmit(event, this);">
                     <div class="verticalSection">
-                        <h2 class="sectionTitle">IMDb Ratings Settings</h2>
-
+                        <h2 class="sectionTitle">Filtering</h2>
                         <div class="inputContainer">
                             <label class="inputLabel" for="txtMinimumVotes">Minimum Votes Threshold</label>
                             <input id="txtMinimumVotes" type="number" min="1" max="1000000"
                                    pattern="[0-9]*" required class="emby-input" />
                             <div class="fieldDescription">
-                                Skip updating items where IMDb has fewer votes than this value. Default: 1.
-                                Lower values can increase task duration because more items qualify for updates.
+                                Skip items where IMDb has fewer votes than this value (default: 1).
                             </div>
                         </div>
+                    </div>
 
+                    <div class="verticalSection">
+                        <h2 class="sectionTitle">Library Types</h2>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
                                 <input id="chkIncludeMovies" type="checkbox" is="emby-checkbox" />
@@ -41,44 +42,68 @@
                                 Update ratings for TV series and individual episodes in your library.
                             </div>
                         </div>
+                    </div>
 
+                    <div class="verticalSection">
+                        <h2 class="sectionTitle">IMDb Ratings Cache</h2>
+                        <div id="cacheStatusContainer" style="margin-bottom: 1em;">
+                            <p id="cacheStatus" style="margin: 0;">Loading cache status&hellip;</p>
+                        </div>
+                        <button id="btnDeleteCache" is="emby-button" type="button"
+                                class="raised button-cancel" disabled>
+                            <span>Delete Cache</span>
+                        </button>
+                        <div class="fieldDescription" style="margin-top: 1em;">
+                            Sourced from the
+                            <a href="https://datasets.imdbws.com/title.ratings.tsv.gz" target="_blank" rel="noopener noreferrer">IMDb ratings flat file</a>.
+                            Cached locally to disk with a 23-hour TTL and re-downloaded
+                            automatically when expired.
+                        </div>
+                        <div class="fieldDescription" style="margin-top: 1em;">
+                            Delete the cache to force a fresh download on the next task run.
+                        </div>
+                    </div>
+
+                    <div class="verticalSection">
+                        <h2 class="sectionTitle">Advanced</h2>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
                                 <input id="chkIncludeSeasonAverages" type="checkbox" is="emby-checkbox" />
                                 <span>Calculate Season Ratings</span>
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">
-                                When enabled, each season's Community Rating is set to the average of eligible
-                                IMDb episode ratings in your library. Episodes without an IMDb rating or below
-                                the minimum votes threshold are excluded. Only has effect when "Include TV Series" is turned on.
+                                Set each season's rating to the average of its episode ratings from IMDb.
+                                Episodes without IMDb data or below the votes threshold are excluded.
+                                Requires "Include TV Series".
                             </div>
                         </div>
-
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
                                 <input id="chkEnableItemDebugLogging" type="checkbox" is="emby-checkbox" />
                                 <span>Enable Item Debug Logs</span>
                             </label>
                             <div class="fieldDescription checkboxFieldDescription">
-                                Off by default. When enabled, writes sampled per-item debug logs for troubleshooting
-                                missing IMDb rows and minimum-vote skips (can increase log volume and task duration).
+                                Writes sampled per-item debug logs for troubleshooting missing IMDb rows and
+                                minimum-vote skips. Can increase log volume and task duration.
                             </div>
                         </div>
                     </div>
 
-                    <div class="verticalSection" style="margin-top: 2em;">
-                        <h2 class="sectionTitle">How It Works</h2>
-                        <p style="margin: 0.5em 0;">
-                            This plugin downloads the official IMDb ratings flat file daily and updates the
-                            <strong>Community Rating</strong> field on all library items that have an IMDb ID.
-                            When enabled, season ratings are calculated as the average of eligible
-                            IMDb episode ratings in your library.
-                            No other metadata (titles, posters, cast, etc.) is modified.
-                        </p>
-                        <p style="margin: 0.5em 0;">
-                            The task runs on a daily schedule (default 3:00 AM) and can also be triggered
-                            manually from <strong>Dashboard &rarr; Scheduled Tasks</strong>.
-                        </p>
+                    <div class="verticalSection" style="margin-top: 1em;">
+                        <details>
+                            <summary style="cursor: pointer; font-weight: 600;">How It Works</summary>
+                            <p style="margin: 0.5em 0;">
+                                This plugin downloads the official IMDb ratings flat file daily and updates the
+                                <strong>Community Rating</strong> field on all library items that have an IMDb ID.
+                                When enabled, season ratings are calculated as the average of eligible
+                                IMDb episode ratings in your library.
+                                No other metadata (titles, posters, cast, etc.) is modified.
+                            </p>
+                            <p style="margin: 0.5em 0;">
+                                The task runs on a daily schedule (default 3:00 AM) and can also be triggered
+                                manually from <strong>Dashboard &rarr; Scheduled Tasks</strong>.
+                            </p>
+                        </details>
                     </div>
 
                     <div>
@@ -192,6 +217,109 @@
 
             return false;
         };
+
+        function formatBytes(bytes) {
+            if (bytes < 1024) {
+                return bytes + ' B';
+            }
+
+            if (bytes < 1024 * 1024) {
+                return (bytes / 1024).toFixed(1) + ' KB';
+            }
+
+            return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+        }
+
+        function formatLocalDateTime(utcDateStr) {
+            var date = new Date(utcDateStr);
+            var year = date.getFullYear();
+            var month = String(date.getMonth() + 1).padStart(2, '0');
+            var day = String(date.getDate()).padStart(2, '0');
+            var hours = String(date.getHours()).padStart(2, '0');
+            var mins = String(date.getMinutes()).padStart(2, '0');
+            var secs = String(date.getSeconds()).padStart(2, '0');
+            return year + '-' + month + '-' + day + ' ' + hours + ':' + mins + ':' + secs;
+        }
+
+        function formatRemainingTime(ms) {
+            if (ms <= 0) {
+                return '0 minutes';
+            }
+
+            var totalMins = Math.floor(ms / 60000);
+            if (totalMins < 60) {
+                return totalMins + ' minute' + (totalMins === 1 ? '' : 's');
+            }
+
+            var hours = Math.floor(totalMins / 60);
+            var mins = totalMins % 60;
+            var result = hours + ' hour' + (hours === 1 ? '' : 's');
+            if (mins > 0) {
+                result += ' ' + mins + ' min';
+            }
+
+            return result;
+        }
+
+        function loadCacheStatus() {
+            var statusEl = document.getElementById('cacheStatus');
+            var deleteBtn = document.getElementById('btnDeleteCache');
+
+            ApiClient.ajax({
+                url: ApiClient.getUrl('ImdbRatings/Cache/Status'),
+                type: 'GET',
+                dataType: 'json'
+            }).then(function (result) {
+                if (!result.Exists && !result.exists) {
+                    statusEl.innerHTML = 'No cache file exists. It will be downloaded on the next task run.';
+                    deleteBtn.disabled = true;
+                    return;
+                }
+
+                var exists = result.Exists || result.exists;
+                var sizeBytes = result.FileSizeBytes || result.fileSizeBytes || 0;
+                var lastModified = result.LastModifiedUtc || result.lastModifiedUtc;
+                var ttlHours = result.TtlHours || result.ttlHours || 23;
+                var isFresh = result.IsFresh || result.isFresh;
+
+                var html = '<strong>Size:</strong> ' + formatBytes(sizeBytes);
+                html += ' &nbsp;|&nbsp; <strong>Downloaded:</strong> ' + formatLocalDateTime(lastModified);
+
+                if (isFresh) {
+                    var ageMs = new Date() - new Date(lastModified);
+                    var remainingMs = (ttlHours * 3600000) - ageMs;
+                    html += ' &nbsp;|&nbsp; <strong>Time to live (TTL):</strong> ' + formatRemainingTime(remainingMs) + ' left';
+                } else {
+                    html += ' &nbsp;|&nbsp; <strong>Time to live (TTL):</strong> Expired';
+                }
+
+                statusEl.innerHTML = html;
+                deleteBtn.disabled = !exists;
+            }).catch(function () {
+                statusEl.innerHTML = 'Unable to load cache status.';
+                deleteBtn.disabled = true;
+            });
+        }
+
+        document.getElementById('btnDeleteCache').addEventListener('click', function () {
+            var deleteBtn = this;
+            deleteBtn.disabled = true;
+
+            ApiClient.ajax({
+                url: ApiClient.getUrl('ImdbRatings/Cache'),
+                type: 'DELETE'
+            }).then(function () {
+                Dashboard.alert('Cache deleted. It will be re-downloaded on the next task run.');
+                loadCacheStatus();
+            }).catch(function () {
+                Dashboard.alert('Failed to delete cache.');
+                loadCacheStatus();
+            });
+        });
+
+        document.getElementById('ImdbRatingsConfigPage').addEventListener('pageshow', function () {
+            loadCacheStatus();
+        });
         </script>
     </div>
 </body>

--- a/Jellyfin.Plugin.ImdbRatings.csproj
+++ b/Jellyfin.Plugin.ImdbRatings.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.11.8" />
     <PackageReference Include="Jellyfin.Model" Version="10.11.8" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ The daily run time is configured in **Dashboard > Scheduled Tasks**; `3:00 AM` i
 - **Include Movies** — update movie ratings
 - **Include TV Series** — update series and episode ratings
 - **Calculate Season Ratings** — set each season's rating to the average of eligible IMDb episode ratings in your library; episodes without IMDb data or below the votes threshold are excluded (requires Include TV Series, default: off)
+- **Cache Management** — view cache file size, age, and freshness status; delete the cache to force a re-download on the next task run

--- a/manifest.json
+++ b/manifest.json
@@ -6,16 +6,8 @@
     "description": "Downloads the IMDb ratings flat file daily and updates CommunityRating on all library items with an IMDb ID, without touching any other metadata.",
     "owner": "voc0der",
     "overview": "Scheduled task that keeps Jellyfin community ratings in sync with IMDb",
-    "imageUrl": "https://raw.githubusercontent.com/pozniakas/jellyfin-imdb-rating-updater/main/icon.png",
+    "imageUrl": "https://raw.githubusercontent.com/voc0der/jellyfin-imdb-rating-updater/main/icon.png",
     "versions": [
-      {
-        "version": "1.0.0.21",
-        "changelog": "## What's Changed\n\n- Update manifest.json for version 1.0.0.20 (38777c0)\n- test: tighten .NET 9 and midpoint coverage (7dae738)\n- chore(deps): Bump actions/setup-dotnet from 5 to 6 (40f1eff)\n- chore(deps): Bump actions/checkout from 6 to 7 (6619bf1)\n- fix: use Episode.SeasonId, retarget tests to net9.0, add CI test step (7b78f8d)\n- Extract SeasonRatingCalculator and add tests (77fb535)\n- fix: address PR review feedback for season ratings (d38c60b)\n- feat: add season ratings calculated from episode averages (ef284ce)\n\n**Full Changelog**: https://github.com/pozniakas/jellyfin-imdb-rating-updater/compare/1.0.0.20...1.0.0.21\n",
-        "targetAbi": "10.11.6.0",
-        "sourceUrl": "https://github.com/pozniakas/jellyfin-imdb-rating-updater/releases/download/1.0.0.21/IMDb_Ratings_1.0.0.21.zip",
-        "checksum": "7f3a09c9566bf018574da28e65792ff5",
-        "timestamp": "2026-08-01T19:26:54Z"
-      },
       {
         "version": "1.0.0.20",
         "changelog": "## What's Changed\n\n- test: tighten .NET 9 and midpoint coverage (7dae738)\n- chore(deps): Bump actions/setup-dotnet from 5 to 6 (40f1eff)\n- chore(deps): Bump actions/checkout from 6 to 7 (6619bf1)\n- fix: use Episode.SeasonId, retarget tests to net9.0, add CI test step (7b78f8d)\n- Extract SeasonRatingCalculator and add tests (77fb535)\n- fix: address PR review feedback for season ratings (d38c60b)\n- feat: add season ratings calculated from episode averages (ef284ce)\n- docs: remove star history section [skip ci] (8da625a)\n- chore: add icon to repo. [skip ci] (0dd3e96)\n\n**Full Changelog**: https://github.com/voc0der/jellyfin-imdb-rating-updater/compare/1.0.0.19...1.0.0.20\n",

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,16 @@
     "description": "Downloads the IMDb ratings flat file daily and updates CommunityRating on all library items with an IMDb ID, without touching any other metadata.",
     "owner": "voc0der",
     "overview": "Scheduled task that keeps Jellyfin community ratings in sync with IMDb",
-    "imageUrl": "https://raw.githubusercontent.com/voc0der/jellyfin-imdb-rating-updater/main/icon.png",
+    "imageUrl": "https://raw.githubusercontent.com/pozniakas/jellyfin-imdb-rating-updater/main/icon.png",
     "versions": [
+      {
+        "version": "1.0.0.21",
+        "changelog": "## What's Changed\n\n- Update manifest.json for version 1.0.0.20 (38777c0)\n- test: tighten .NET 9 and midpoint coverage (7dae738)\n- chore(deps): Bump actions/setup-dotnet from 5 to 6 (40f1eff)\n- chore(deps): Bump actions/checkout from 6 to 7 (6619bf1)\n- fix: use Episode.SeasonId, retarget tests to net9.0, add CI test step (7b78f8d)\n- Extract SeasonRatingCalculator and add tests (77fb535)\n- fix: address PR review feedback for season ratings (d38c60b)\n- feat: add season ratings calculated from episode averages (ef284ce)\n\n**Full Changelog**: https://github.com/pozniakas/jellyfin-imdb-rating-updater/compare/1.0.0.20...1.0.0.21\n",
+        "targetAbi": "10.11.6.0",
+        "sourceUrl": "https://github.com/pozniakas/jellyfin-imdb-rating-updater/releases/download/1.0.0.21/IMDb_Ratings_1.0.0.21.zip",
+        "checksum": "7f3a09c9566bf018574da28e65792ff5",
+        "timestamp": "2026-08-01T19:26:54Z"
+      },
       {
         "version": "1.0.0.20",
         "changelog": "## What's Changed\n\n- test: tighten .NET 9 and midpoint coverage (7dae738)\n- chore(deps): Bump actions/setup-dotnet from 5 to 6 (40f1eff)\n- chore(deps): Bump actions/checkout from 6 to 7 (6619bf1)\n- fix: use Episode.SeasonId, retarget tests to net9.0, add CI test step (7b78f8d)\n- Extract SeasonRatingCalculator and add tests (77fb535)\n- fix: address PR review feedback for season ratings (d38c60b)\n- feat: add season ratings calculated from episode averages (ef284ce)\n- docs: remove star history section [skip ci] (8da625a)\n- chore: add icon to repo. [skip ci] (0dd3e96)\n\n**Full Changelog**: https://github.com/voc0der/jellyfin-imdb-rating-updater/compare/1.0.0.19...1.0.0.20\n",

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/CacheControllerTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/CacheControllerTests.cs
@@ -1,0 +1,211 @@
+using Jellyfin.Plugin.ImdbRatings.Api;
+using MediaBrowser.Common.Configuration;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+public class CacheControllerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public CacheControllerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "imdb-cache-tests-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetStatus_NoCacheFile_ReturnsExistsFalse()
+    {
+        var controller = CreateController();
+
+        var result = controller.GetStatus();
+
+        var dto = GetValue(result);
+        Assert.False(dto.Exists);
+        Assert.Equal(0, dto.FileSizeBytes);
+        Assert.Null(dto.LastModifiedUtc);
+        Assert.False(dto.IsFresh);
+        Assert.Equal(23.0, dto.TtlHours);
+    }
+
+    [Fact]
+    public void GetStatus_FreshCache_ReturnsCorrectInfo()
+    {
+        var cachePath = CreateCacheFile("tconst\taverageRating\tnumVotes\ntt0000001\t7.5\t1000\n");
+
+        var controller = CreateController();
+        var result = controller.GetStatus();
+
+        var dto = GetValue(result);
+        Assert.True(dto.Exists);
+        Assert.True(dto.FileSizeBytes > 0);
+        Assert.NotNull(dto.LastModifiedUtc);
+        Assert.True(dto.IsFresh);
+    }
+
+    [Fact]
+    public void GetStatus_ExpiredCache_ReturnsIsFreshFalse()
+    {
+        var cachePath = CreateCacheFile("tconst\taverageRating\tnumVotes\n");
+        File.SetLastWriteTimeUtc(cachePath, DateTime.UtcNow.AddHours(-24));
+
+        var controller = CreateController();
+        var result = controller.GetStatus();
+
+        var dto = GetValue(result);
+        Assert.True(dto.Exists);
+        Assert.False(dto.IsFresh);
+    }
+
+    [Fact]
+    public void Delete_CacheExists_DeletesFileAndReturnsNoContent()
+    {
+        var cachePath = CreateCacheFile("tconst\taverageRating\tnumVotes\n");
+        Assert.True(File.Exists(cachePath));
+
+        var controller = CreateController();
+        var result = controller.Delete();
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.False(File.Exists(cachePath));
+    }
+
+    [Fact]
+    public void Delete_TempFileExists_AlsoDeleted()
+    {
+        var cachePath = CreateCacheFile("data");
+        var tempPath = cachePath + ".tmp";
+        File.WriteAllText(tempPath, "partial");
+
+        var controller = CreateController();
+        controller.Delete();
+
+        Assert.False(File.Exists(cachePath));
+        Assert.False(File.Exists(tempPath));
+    }
+
+    [Fact]
+    public void Delete_NoCacheFile_ReturnsNotFound()
+    {
+        var controller = CreateController();
+        var result = controller.Delete();
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public void Delete_OnlyTempFileExists_ReturnsNoContent()
+    {
+        var cacheDir = Path.Combine(_tempDir, "imdb-ratings-cache");
+        Directory.CreateDirectory(cacheDir);
+        var tempPath = Path.Combine(cacheDir, "title.ratings.tsv.tmp");
+        File.WriteAllText(tempPath, "partial download");
+
+        var controller = CreateController();
+        var result = controller.Delete();
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.False(File.Exists(tempPath));
+    }
+
+    [Fact]
+    public void GetStatus_CacheJustWithinTtl_ReportsAsFresh()
+    {
+        var cachePath = CreateCacheFile("tconst\taverageRating\tnumVotes\n");
+        File.SetLastWriteTimeUtc(cachePath, DateTime.UtcNow.AddHours(-22).AddMinutes(-59));
+
+        var controller = CreateController();
+        var result = controller.GetStatus();
+
+        var dto = GetValue(result);
+        Assert.True(dto.IsFresh);
+    }
+
+    [Fact]
+    public void GetStatus_CacheJustPastTtl_ReportsAsExpired()
+    {
+        var cachePath = CreateCacheFile("tconst\taverageRating\tnumVotes\n");
+        File.SetLastWriteTimeUtc(cachePath, DateTime.UtcNow.AddHours(-23).AddMinutes(-1));
+
+        var controller = CreateController();
+        var result = controller.GetStatus();
+
+        var dto = GetValue(result);
+        Assert.False(dto.IsFresh);
+    }
+
+    private CacheController CreateController()
+    {
+        return new CacheController(new FakeApplicationPaths(_tempDir));
+    }
+
+    private string CreateCacheFile(string content)
+    {
+        var cacheDir = Path.Combine(_tempDir, "imdb-ratings-cache");
+        Directory.CreateDirectory(cacheDir);
+        var cachePath = Path.Combine(cacheDir, "title.ratings.tsv");
+        File.WriteAllText(cachePath, content);
+        return cachePath;
+    }
+
+    private static CacheStatusDto GetValue(ActionResult<CacheStatusDto> result)
+    {
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        return Assert.IsType<CacheStatusDto>(okResult.Value);
+    }
+
+    private sealed class FakeApplicationPaths : IApplicationPaths
+    {
+        public FakeApplicationPaths(string dataPath)
+        {
+            DataPath = dataPath;
+        }
+
+        public string ProgramDataPath => string.Empty;
+
+        public string WebPath => string.Empty;
+
+        public string ProgramSystemPath => string.Empty;
+
+        public string DataPath { get; }
+
+        public string ImageCachePath => string.Empty;
+
+        public string PluginsPath => string.Empty;
+
+        public string PluginConfigurationsPath => string.Empty;
+
+        public string LogDirectoryPath => string.Empty;
+
+        public string ConfigurationDirectoryPath => string.Empty;
+
+        public string SystemConfigurationFilePath => string.Empty;
+
+        public string CachePath => string.Empty;
+
+        public string TempDirectory => string.Empty;
+
+        public string VirtualDataPath => string.Empty;
+
+        public string TrickplayPath => string.Empty;
+
+        public string BackupPath => string.Empty;
+
+        public void MakeSanityCheckOrThrow()
+        {
+        }
+
+        public void CreateAndCheckMarker(string name, string value, bool overwrite = false)
+        {
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/Jellyfin.Plugin.ImdbRatings.Tests.csproj
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/Jellyfin.Plugin.ImdbRatings.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.0" />


### PR DESCRIPTION
### Summary

Adds visibility and control over the IMDb ratings dataset cache directly from the plugin configuration page.

<img width="400" height="304" alt="image" src="https://github.com/user-attachments/assets/e4fb26a2-4299-4a2a-ac6b-4732f2fa67c5" />

<img width="360" height="480" alt="image" src="https://github.com/user-attachments/assets/9e7380a7-2fef-41d5-ae64-ad19cfd668ce" />


### Changes

- **API endpoints** (`Api/CacheController.cs`): admin-only `GET /ImdbRatings/Cache/Status` and `DELETE /ImdbRatings/Cache` for querying and clearing the cached ratings file
- **Config page**: displays cache file size, download timestamp, and TTL countdown; "Delete Cache" button to force re-download on next task run
- **Page layout**: reorganized into clear sections — Filtering, Library Types, IMDb Ratings Cache, Advanced, and a collapsible "How It Works"
- **Project**: added `FrameworkReference` for `Microsoft.AspNetCore.App` to support the controller
- **Tests** (`CacheControllerTests.cs`): 9 unit tests covering GetStatus (no file, fresh, expired, TTL boundary) and Delete (exists, temp-only, not found)

### Context

The IMDb ratings file (~2 MB compressed, ~28 MB on disk) is downloaded daily and cached for 23 hours. Previously there was no way to see its status or manually invalidate it without accessing the server filesystem. This gives admins a one-click way to force a fresh download.