### PR TITLE
feat: Apply IMDb ratings at library-scan time

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -19,5 +19,11 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool IncludeSeasonAverages { get; set; } = false;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether ratings are also supplied at library-scan time.
+    /// When enabled the scheduled task writes a compact index (~15 MB) that the metadata provider reads.
+    /// </summary>
+    public bool EnableMetadataProvider { get; set; } = true;
+
     public bool EnableItemDebugLogging { get; set; } = false;
 }

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -56,6 +56,19 @@
 
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label>
+                                <input id="chkEnableMetadataProvider" type="checkbox" is="emby-checkbox" />
+                                <span>Apply Ratings During Library Scans</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">
+                                On by default. Newly scanned items get their IMDb rating immediately instead of waiting
+                                for the next scheduled run. The task writes a compact index (about 15 MB on disk, and the
+                                same in memory once loaded) that this reads. Turn off to save that memory; the daily task
+                                keeps working either way.
+                            </div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
                                 <input id="chkEnableItemDebugLogging" type="checkbox" is="emby-checkbox" />
                                 <span>Enable Item Debug Logs</span>
                             </label>
@@ -149,6 +162,11 @@
                 document.getElementById('chkIncludeMovies').checked = !!getConfigValue(config, 'IncludeMovies', 'includeMovies', true);
                 document.getElementById('chkIncludeSeries').checked = !!getConfigValue(config, 'IncludeSeries', 'includeSeries', true);
                 document.getElementById('chkIncludeSeasonAverages').checked = !!getConfigValue(config, 'IncludeSeasonAverages', 'includeSeasonAverages', false);
+                document.getElementById('chkEnableMetadataProvider').checked = !!getConfigValue(
+                    config,
+                    'EnableMetadataProvider',
+                    'enableMetadataProvider',
+                    true);
                 document.getElementById('chkEnableItemDebugLogging').checked = !!getConfigValue(
                     config,
                     'EnableItemDebugLogging',
@@ -173,6 +191,11 @@
                 setConfigValue(config, 'IncludeMovies', 'includeMovies', document.getElementById('chkIncludeMovies').checked);
                 setConfigValue(config, 'IncludeSeries', 'includeSeries', document.getElementById('chkIncludeSeries').checked);
                 setConfigValue(config, 'IncludeSeasonAverages', 'includeSeasonAverages', document.getElementById('chkIncludeSeasonAverages').checked);
+                setConfigValue(
+                    config,
+                    'EnableMetadataProvider',
+                    'enableMetadataProvider',
+                    document.getElementById('chkEnableMetadataProvider').checked);
                 setConfigValue(
                     config,
                     'EnableItemDebugLogging',

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Jellyfin.Plugin.ImdbRatings.Configuration;
+using Jellyfin.Plugin.ImdbRatings.Providers;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
@@ -23,6 +25,30 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public override string Description => "Downloads the IMDb ratings flat file daily and updates CommunityRating on all library items with an IMDb ID.";
 
     public static Plugin? Instance { get; private set; }
+
+    /// <inheritdoc />
+    public override void UpdateConfiguration(BasePluginConfiguration configuration)
+    {
+        base.UpdateConfiguration(configuration);
+
+        if (configuration is not PluginConfiguration { EnableMetadataProvider: false })
+        {
+            return;
+        }
+
+        // Apply the memory/disk saving promised by the toggle immediately. The scheduled task repeats this
+        // cleanup with logging, so a transient sharing or permission failure is retried on its next run.
+        ImdbRatingsIndexCache.InvalidateShared();
+        try
+        {
+            File.Delete(ImdbRatingsIndex.GetIndexPath(ApplicationPaths.DataPath));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Configuration has already been saved. Do not turn a best-effort cache cleanup into a failed
+            // settings update; the scheduled task will retry and log the failure.
+        }
+    }
 
     public IEnumerable<PluginPageInfo> GetPages()
     {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Jellyfin.Plugin.ImdbRatings.Tests")]

--- a/Providers/ImdbRatingsIndex.cs
+++ b/Providers/ImdbRatingsIndex.cs
@@ -1,0 +1,423 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.ImdbRatings.Providers;
+
+/// <summary>
+/// Compact on-disk index of IMDb ratings, sized for random-access lookups by the metadata provider.
+/// </summary>
+/// <remarks>
+/// The IMDb ratings flat file is ~30 MB of TSV that costs roughly a second to parse. The provider needs
+/// single-key lookups on every scanned item, so the scheduled task writes this index as a byproduct of the
+/// parse it already performs and the provider loads it with sequential buffered reads instead.
+///
+/// Layout (multi-byte values little-endian):
+/// <code>
+///   magic      8 bytes   "IMDBRIDX"
+///   version    4 bytes   uint32
+///   count      4 bytes   uint32
+///   ids        4 * count uint32, ascending
+///   ratings    1 * count byte, averageRating * 10 (10..100)
+///   votes      4 * count uint32
+/// </code>
+/// Ratings are stored as a single byte because IMDb publishes exactly one decimal place; votes are kept
+/// verbatim so the minimum-votes threshold stays a runtime setting rather than something baked in at build time.
+/// </remarks>
+public sealed class ImdbRatingsIndex
+{
+    /// <summary>
+    /// Current on-disk format version. Bump when the layout changes so stale indexes are discarded.
+    /// </summary>
+    public const uint FormatVersion = 1;
+
+    private const int HeaderSize = 16;
+    private const int MaxCount = 20_000_000;
+    private const int TransferBufferSize = 128 * 1024;
+    private static readonly byte[] MagicBytes = "IMDBRIDX"u8.ToArray();
+
+    private readonly uint[] _ids;
+    private readonly byte[] _ratings;
+    private readonly uint[] _votes;
+
+    private ImdbRatingsIndex(uint[] ids, byte[] ratings, uint[] votes)
+    {
+        _ids = ids;
+        _ratings = ratings;
+        _votes = votes;
+    }
+
+    /// <summary>
+    /// Gets the number of rated titles held in the index.
+    /// </summary>
+    public int Count => _ids.Length;
+
+    /// <summary>
+    /// Gets the approximate resident size of the index in bytes.
+    /// </summary>
+    public long ApproximateSizeInBytes => ((long)_ids.Length * sizeof(uint))
+        + _ratings.Length
+        + ((long)_votes.Length * sizeof(uint));
+
+    /// <summary>
+    /// Gets the path the index is written to for a given Jellyfin data directory.
+    /// </summary>
+    public static string GetIndexPath(string dataPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataPath);
+        return Path.Join(dataPath, "imdb-ratings-cache", "title.ratings.idx");
+    }
+
+    /// <summary>
+    /// Converts an IMDb rating to the single-byte form used on disk.
+    /// </summary>
+    public static byte EncodeRating(float rating)
+    {
+        var scaled = (int)MathF.Round(rating * 10f, MidpointRounding.AwayFromZero);
+        return (byte)Math.Clamp(scaled, 0, byte.MaxValue);
+    }
+
+    /// <summary>
+    /// Parses a "tt"-prefixed IMDb ID into its numeric form, rejecting anything wider than a <see cref="uint"/>.
+    /// </summary>
+    public static bool TryParseImdbId(string? imdbId, out uint numericId)
+    {
+        numericId = 0;
+
+        if (string.IsNullOrEmpty(imdbId)
+            || imdbId.Length < 3
+            || imdbId[0] != 't'
+            || imdbId[1] != 't')
+        {
+            return false;
+        }
+
+        ulong accumulator = 0;
+        for (int i = 2; i < imdbId.Length; i++)
+        {
+            char c = imdbId[i];
+            if (c < '0' || c > '9')
+            {
+                return false;
+            }
+
+            accumulator = (accumulator * 10) + (ulong)(c - '0');
+            if (accumulator > uint.MaxValue)
+            {
+                return false;
+            }
+        }
+
+        numericId = (uint)accumulator;
+        return true;
+    }
+
+    /// <summary>
+    /// Builds an index from parallel arrays, sorting them into ascending ID order.
+    /// </summary>
+    /// <remarks>
+    /// The source arrays are sorted in place. The IMDb flat file is byte-sorted rather than numerically sorted
+    /// (tt10001002 precedes tt9916850), so an explicit sort is required before binary search is valid.
+    /// </remarks>
+    public static ImdbRatingsIndex CreateSorted(uint[] ids, byte[] ratings, uint[] votes)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+        ArgumentNullException.ThrowIfNull(ratings);
+        ArgumentNullException.ThrowIfNull(votes);
+
+        if (ids.Length != ratings.Length || ids.Length != votes.Length)
+        {
+            throw new ArgumentException("Index arrays must all be the same length.", nameof(ids));
+        }
+
+        // Sort a packed payload alongside the keys so both value arrays follow the key permutation.
+        var payload = new ulong[ids.Length];
+        for (int i = 0; i < ids.Length; i++)
+        {
+            payload[i] = ((ulong)ratings[i] << 32) | votes[i];
+        }
+
+        Array.Sort(ids, payload);
+
+        for (int i = 0; i < ids.Length; i++)
+        {
+            ratings[i] = (byte)(payload[i] >> 32);
+            votes[i] = (uint)(payload[i] & 0xFFFFFFFF);
+        }
+
+        return new ImdbRatingsIndex(ids, ratings, votes);
+    }
+
+    /// <summary>
+    /// Looks up a rating by IMDb ID, honouring the supplied minimum-votes threshold.
+    /// </summary>
+    public bool TryGetRating(string? imdbId, int minimumVotes, out float rating, out int votes)
+    {
+        rating = 0;
+        votes = 0;
+
+        if (!TryParseImdbId(imdbId, out var numericId))
+        {
+            return false;
+        }
+
+        int position = Array.BinarySearch(_ids, numericId);
+        if (position < 0)
+        {
+            return false;
+        }
+
+        var candidateVotes = _votes[position];
+        if (candidateVotes < (uint)Math.Max(minimumVotes, 0))
+        {
+            return false;
+        }
+
+        rating = _ratings[position] / 10f;
+        votes = (int)Math.Min(candidateVotes, int.MaxValue);
+        return true;
+    }
+
+    /// <summary>
+    /// Writes the index to disk, replacing any existing file atomically.
+    /// </summary>
+    public async Task WriteAsync(string indexPath, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(indexPath);
+
+        var directory = Path.GetDirectoryName(indexPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var tempPath = indexPath + ".tmp";
+
+        try
+        {
+            var header = new byte[HeaderSize];
+            MagicBytes.CopyTo(header, 0);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(8, 4), FormatVersion);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(12, 4), (uint)_ids.Length);
+
+            var stream = new FileStream(
+                tempPath,
+                new FileStreamOptions
+                {
+                    Access = FileAccess.Write,
+                    Mode = FileMode.Create,
+                    Options = FileOptions.Asynchronous,
+                    PreallocationSize = GetPayloadSize(_ids.Length),
+                    Share = FileShare.None
+                });
+
+            await using (stream.ConfigureAwait(false))
+            {
+                byte[] transferBuffer = ArrayPool<byte>.Shared.Rent(TransferBufferSize);
+                try
+                {
+                    await stream.WriteAsync(header, cancellationToken).ConfigureAwait(false);
+                    await WriteArrayAsync(stream, _ids, transferBuffer, cancellationToken).ConfigureAwait(false);
+                    await stream.WriteAsync(_ratings, cancellationToken).ConfigureAwait(false);
+                    await WriteArrayAsync(stream, _votes, transferBuffer, cancellationToken).ConfigureAwait(false);
+                    await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(transferBuffer);
+                }
+            }
+
+            File.Move(tempPath, indexPath, overwrite: true);
+        }
+        catch
+        {
+            TryDelete(tempPath);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Loads an index from disk, returning <see langword="null"/> when the file is absent, truncated,
+    /// or written by a different format version.
+    /// </summary>
+    public static async Task<ImdbRatingsIndex?> TryLoadAsync(string indexPath, CancellationToken cancellationToken)
+    {
+        return await TryLoadAsync(indexPath, cancellationToken, afterOpen: null).ConfigureAwait(false);
+    }
+
+    internal static async Task<ImdbRatingsIndex?> TryLoadAsync(
+        string indexPath,
+        CancellationToken cancellationToken,
+        Func<CancellationToken, Task>? afterOpen)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(indexPath);
+
+        FileStream stream;
+        try
+        {
+            stream = new FileStream(
+                indexPath,
+                new FileStreamOptions
+                {
+                    Access = FileAccess.Read,
+                    Mode = FileMode.Open,
+                    Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                    // Replacement is atomic only if readers permit the old directory entry to be renamed/deleted
+                    // on Windows while this handle is still consuming it.
+                    Share = FileShare.Read | FileShare.Delete
+                });
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return null;
+        }
+
+        await using (stream.ConfigureAwait(false))
+        {
+            if (afterOpen is not null)
+            {
+                await afterOpen(cancellationToken).ConfigureAwait(false);
+            }
+
+            // Validate the header before allocating anything sized by the file, so a corrupt or bloated
+            // index is rejected rather than turned into a multi-hundred-megabyte allocation.
+            if (stream.Length < HeaderSize || stream.Length > GetPayloadSizeUnchecked(MaxCount))
+            {
+                return null;
+            }
+
+            var header = new byte[HeaderSize];
+            if (!await TryReadExactlyAsync(stream, header, cancellationToken).ConfigureAwait(false)
+                || !header.AsSpan(0, MagicBytes.Length).SequenceEqual(MagicBytes)
+                || BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(8, 4)) != FormatVersion)
+            {
+                return null;
+            }
+
+            var count = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(12, 4));
+            if (count > MaxCount || stream.Length != GetPayloadSizeUnchecked((long)count))
+            {
+                return null;
+            }
+
+            var ids = new uint[count];
+            var ratings = new byte[count];
+            var votes = new uint[count];
+
+            byte[] transferBuffer = ArrayPool<byte>.Shared.Rent(TransferBufferSize);
+            try
+            {
+                if (!await TryReadArrayAsync(stream, ids, transferBuffer, cancellationToken).ConfigureAwait(false)
+                    || !await TryReadExactlyAsync(stream, ratings, cancellationToken).ConfigureAwait(false)
+                    || !await TryReadArrayAsync(stream, votes, transferBuffer, cancellationToken).ConfigureAwait(false))
+                {
+                    return null;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(transferBuffer);
+            }
+
+            return new ImdbRatingsIndex(ids, ratings, votes);
+        }
+    }
+
+    private static async Task WriteArrayAsync(
+        Stream stream,
+        Array source,
+        byte[] transferBuffer,
+        CancellationToken cancellationToken)
+    {
+        int sourceOffset = 0;
+        int bytesRemaining = Buffer.ByteLength(source);
+        while (bytesRemaining > 0)
+        {
+            int bytesToWrite = Math.Min(bytesRemaining, transferBuffer.Length);
+            Buffer.BlockCopy(source, sourceOffset, transferBuffer, 0, bytesToWrite);
+            await stream.WriteAsync(transferBuffer.AsMemory(0, bytesToWrite), cancellationToken).ConfigureAwait(false);
+            sourceOffset += bytesToWrite;
+            bytesRemaining -= bytesToWrite;
+        }
+    }
+
+    private static async Task<bool> TryReadArrayAsync(
+        Stream stream,
+        Array destination,
+        byte[] transferBuffer,
+        CancellationToken cancellationToken)
+    {
+        int destinationOffset = 0;
+        int bytesRemaining = Buffer.ByteLength(destination);
+        while (bytesRemaining > 0)
+        {
+            int bytesToRead = Math.Min(bytesRemaining, transferBuffer.Length);
+            if (!await TryReadExactlyAsync(
+                    stream,
+                    transferBuffer.AsMemory(0, bytesToRead),
+                    cancellationToken).ConfigureAwait(false))
+            {
+                return false;
+            }
+
+            Buffer.BlockCopy(transferBuffer, 0, destination, destinationOffset, bytesToRead);
+            destinationOffset += bytesToRead;
+            bytesRemaining -= bytesToRead;
+        }
+
+        return true;
+    }
+
+    private static async Task<bool> TryReadExactlyAsync(
+        Stream stream,
+        Memory<byte> destination,
+        CancellationToken cancellationToken)
+    {
+        int totalRead = 0;
+        while (totalRead < destination.Length)
+        {
+            int read = await stream.ReadAsync(destination[totalRead..], cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                return false;
+            }
+
+            totalRead += read;
+        }
+
+        return true;
+    }
+
+    private static long GetPayloadSizeUnchecked(long count)
+    {
+        return HeaderSize + (count * sizeof(uint)) + count + (count * sizeof(uint));
+    }
+
+    private static int GetPayloadSize(int count)
+    {
+        return (int)GetPayloadSizeUnchecked(count);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // Best effort cleanup of the temp file.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best effort cleanup of the temp file.
+        }
+    }
+}

--- a/Providers/ImdbRatingsIndexCache.cs
+++ b/Providers/ImdbRatingsIndexCache.cs
@@ -1,0 +1,326 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.ImdbRatings.Providers;
+
+/// <summary>
+/// Holds the loaded <see cref="ImdbRatingsIndex"/> for the lifetime of the process, reloading it when the
+/// scheduled task replaces the file on disk.
+/// </summary>
+/// <remarks>
+/// The scheduled task is the sole writer of the index and this cache is a pure reader: it never downloads
+/// and never builds. That keeps scan-time lookups free of network I/O and means a fresh install simply has
+/// no ratings to serve until the task has run once.
+/// </remarks>
+public sealed class ImdbRatingsIndexCache
+{
+    private static readonly TimeSpan RecheckInterval = TimeSpan.FromSeconds(60);
+    private static readonly object SharedLock = new();
+
+    private static ImdbRatingsIndexCache? _shared;
+    private static string? _sharedIndexPath;
+
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly object _stateLock = new();
+    private readonly string _indexPath;
+    private readonly ILogger _logger;
+    private readonly Func<string, CancellationToken, Task<ImdbRatingsIndex?>> _loadIndexAsync;
+    private readonly Func<string, DateTime> _getWriteTimeUtc;
+    private readonly TimeProvider _timeProvider;
+
+    private ImdbRatingsIndex? _index;
+    private DateTime _observedWriteTimeUtc;
+    private DateTime _lastCheckUtc = DateTime.MinValue;
+    private bool _hasChecked;
+    private long _generation;
+
+    public ImdbRatingsIndexCache(string indexPath, ILogger logger)
+        : this(indexPath, logger, ImdbRatingsIndex.TryLoadAsync, TimeProvider.System, GetWriteTimeUtc)
+    {
+    }
+
+    internal ImdbRatingsIndexCache(
+        string indexPath,
+        ILogger logger,
+        Func<string, CancellationToken, Task<ImdbRatingsIndex?>> loadIndexAsync,
+        TimeProvider? timeProvider = null,
+        Func<string, DateTime>? getWriteTimeUtc = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(indexPath);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(loadIndexAsync);
+
+        _indexPath = indexPath;
+        _logger = logger;
+        _loadIndexAsync = loadIndexAsync;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _getWriteTimeUtc = getWriteTimeUtc ?? GetWriteTimeUtc;
+    }
+
+    /// <summary>
+    /// Gets the process-wide cache for a given index path.
+    /// </summary>
+    /// <remarks>
+    /// The loaded index is roughly 15 MB, so it is shared rather than held per provider instance: Jellyfin
+    /// makes no guarantee about how many times a metadata provider type is constructed.
+    /// </remarks>
+    public static ImdbRatingsIndexCache GetShared(string indexPath, ILogger logger)
+    {
+        lock (SharedLock)
+        {
+            if (_shared is null || !string.Equals(_sharedIndexPath, indexPath, StringComparison.Ordinal))
+            {
+                _shared = new ImdbRatingsIndexCache(indexPath, logger);
+                _sharedIndexPath = indexPath;
+            }
+
+            return _shared;
+        }
+    }
+
+    /// <summary>
+    /// Releases the process-wide cache, if one has been created. Used by the scheduled task so a rebuilt or
+    /// deleted index takes effect immediately rather than at the next recheck interval.
+    /// </summary>
+    public static void InvalidateShared()
+    {
+        lock (SharedLock)
+        {
+            _shared?.Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// Gets the current index, reloading from disk when the file has changed since the last check.
+    /// Returns <see langword="null"/> when no usable index exists yet.
+    /// </summary>
+    public async Task<ImdbRatingsIndex?> GetIndexAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            // A negative result is cached just like a positive one: without this, every scanned item on a server
+            // with no index would stat the file, and every item on a server with a corrupt index would re-read
+            // and re-validate the whole thing behind the gate.
+            if (TryGetFreshConclusion(out var cachedIndex))
+            {
+                return cachedIndex;
+            }
+
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            long attemptGeneration = -1;
+            try
+            {
+                // Another caller may have refreshed while this one waited on the gate.
+                if (TryGetFreshConclusion(out cachedIndex))
+                {
+                    return cachedIndex;
+                }
+
+                long generation;
+                DateTime observedWriteTimeUtc;
+                ImdbRatingsIndex? previousIndex;
+                lock (_stateLock)
+                {
+                    generation = _generation;
+                    attemptGeneration = generation;
+                    observedWriteTimeUtc = _observedWriteTimeUtc;
+                    previousIndex = _index;
+                }
+
+                var writeTimeUtc = GetWriteTimeUtcOrDefault();
+                if (writeTimeUtc == default)
+                {
+                    if (!TryCommitConclusion(generation, default, null, out _))
+                    {
+                        continue;
+                    }
+
+                    if (previousIndex is not null)
+                    {
+                        _logger.LogInformation("IMDb ratings index disappeared from {Path}; scan-time ratings paused", _indexPath);
+                    }
+
+                    return null;
+                }
+
+                // The file is unchanged since the last evaluation, so the previous conclusion still holds —
+                // including the conclusion that it was unreadable.
+                if (writeTimeUtc == observedWriteTimeUtc)
+                {
+                    if (TryRefreshConclusion(generation, out var unchangedIndex))
+                    {
+                        return unchangedIndex;
+                    }
+
+                    continue;
+                }
+
+                // Do not publish the new mtime until the cancellable load has reached a completed conclusion.
+                // A cancellation therefore leaves the old state retryable by the next caller.
+                var loaded = await _loadIndexAsync(_indexPath, cancellationToken).ConfigureAwait(false);
+                if (loaded is null)
+                {
+                    if (!TryCommitConclusion(generation, writeTimeUtc, null, out _))
+                    {
+                        continue;
+                    }
+
+                    _logger.LogWarning(
+                        "IMDb ratings index at {Path} is unreadable or has an unexpected format; it will be rebuilt on the next scheduled run",
+                        _indexPath);
+                    return null;
+                }
+
+                if (!TryCommitConclusion(generation, writeTimeUtc, loaded, out var committedIndex))
+                {
+                    // Invalidation won while the file was being read. Discard this generation and retry the
+                    // same lookup so the current item can use the rebuilt index rather than recording a miss.
+                    continue;
+                }
+
+                _logger.LogInformation(
+                    "Loaded IMDb ratings index: {Count} titles, {SizeMb:F1} MB resident",
+                    loaded.Count,
+                    loaded.ApproximateSizeInBytes / (1024d * 1024d));
+
+                return committedIndex;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                _logger.LogWarning(ex, "Failed to load IMDb ratings index from {Path}", _indexPath);
+
+                // Throttle a transient failure, but retain the last good index and the previously observed mtime.
+                // Because the failed mtime is not committed, it will be retried after the interval expires.
+                if (TryRecordTransientFailure(attemptGeneration, out var fallbackIndex))
+                {
+                    return fallbackIndex;
+                }
+
+                continue;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Releases the cached index so its memory can be reclaimed, and forces the next lookup to reload.
+    /// </summary>
+    public void Invalidate()
+    {
+        lock (_stateLock)
+        {
+            _generation++;
+            _index = null;
+            _observedWriteTimeUtc = default;
+            _lastCheckUtc = DateTime.MinValue;
+            _hasChecked = false;
+        }
+    }
+
+    private bool TryGetFreshConclusion(out ImdbRatingsIndex? index)
+    {
+        lock (_stateLock)
+        {
+            if (_hasChecked && GetUtcNow() - _lastCheckUtc < RecheckInterval)
+            {
+                index = _index;
+                return true;
+            }
+
+            index = null;
+            return false;
+        }
+    }
+
+    private bool TryCommitConclusion(
+        long generation,
+        DateTime observedWriteTimeUtc,
+        ImdbRatingsIndex? index,
+        out ImdbRatingsIndex? committedIndex)
+    {
+        lock (_stateLock)
+        {
+            if (_generation != generation)
+            {
+                committedIndex = null;
+                return false;
+            }
+
+            _index = index;
+            _observedWriteTimeUtc = observedWriteTimeUtc;
+            _lastCheckUtc = GetUtcNow();
+            _hasChecked = true;
+            committedIndex = index;
+            return true;
+        }
+    }
+
+    private bool TryRefreshConclusion(long generation, out ImdbRatingsIndex? index)
+    {
+        lock (_stateLock)
+        {
+            if (_generation != generation)
+            {
+                index = null;
+                return false;
+            }
+
+            _lastCheckUtc = GetUtcNow();
+            _hasChecked = true;
+            index = _index;
+            return true;
+        }
+    }
+
+    private bool TryRecordTransientFailure(long generation, out ImdbRatingsIndex? index)
+    {
+        lock (_stateLock)
+        {
+            // Invalidation clears _hasChecked and advances the generation while a load is running. Do not
+            // turn that invalidated state back into a cached conclusion from this older attempt.
+            if (_generation != generation)
+            {
+                index = null;
+                return false;
+            }
+
+            _lastCheckUtc = GetUtcNow();
+            _hasChecked = true;
+            index = _index;
+            return true;
+        }
+    }
+
+    private DateTime GetWriteTimeUtcOrDefault()
+    {
+        try
+        {
+            return _getWriteTimeUtc(_indexPath);
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return default;
+        }
+    }
+
+    private static DateTime GetWriteTimeUtc(string indexPath)
+    {
+        using var handle = File.OpenHandle(
+            indexPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read | FileShare.Delete);
+        return File.GetLastWriteTimeUtc(handle);
+    }
+
+    private DateTime GetUtcNow()
+    {
+        return _timeProvider.GetUtcNow().UtcDateTime;
+    }
+}

--- a/Providers/ImdbRatingsItemProvider.cs
+++ b/Providers/ImdbRatingsItemProvider.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.ImdbRatings.Configuration;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.ImdbRatings.Providers;
+
+/// <summary>
+/// Applies IMDb community ratings at library-scan time, so newly added items are rated immediately
+/// rather than waiting for the next scheduled refresh.
+/// </summary>
+/// <remarks>
+/// This is deliberately an <see cref="ICustomMetadataProvider{TItemType}"/> rather than an
+/// <see cref="IRemoteMetadataProvider{TItemType, TLookupInfo}"/>, for two reasons that are both fatal to the
+/// remote-provider approach:
+///
+/// <para>
+/// Ordering. Jellyfin propagates newly discovered provider IDs to the lookup info only *after* each remote
+/// provider returns, and merges community ratings on a first-non-null-wins basis. A remote provider ordered
+/// before TMDb therefore has no IMDb ID to look up on a normally identified new item, while one ordered after
+/// TMDb has the ID but finds its rating discarded because TMDb already supplied one. Custom providers run
+/// after the whole remote merge completes and mutate the item directly, so neither problem applies.
+/// </para>
+///
+/// <para>
+/// Enablement. <c>ProviderManager.CanRefreshMetadata</c> only consults the library's <c>MetadataFetchers</c>
+/// allowlist for <see cref="IRemoteMetadataProvider"/>s. A newly introduced fetcher name is absent from every
+/// existing library's saved list, so a remote provider would silently never run. Custom providers bypass that
+/// check, which makes the plugin's own toggle the single source of truth.
+/// </para>
+///
+/// Seasons are deliberately not handled here. A season rating is the average of its episodes' ratings, which
+/// needs the whole season in hand rather than a single item, so it stays with the scheduled task.
+/// </remarks>
+public class ImdbRatingsItemProvider :
+    ICustomMetadataProvider<Movie>,
+    ICustomMetadataProvider<Series>,
+    ICustomMetadataProvider<Episode>
+{
+    private readonly ImdbRatingsIndexCache _indexCache;
+    private readonly ILogger<ImdbRatingsItemProvider> _logger;
+
+    public ImdbRatingsItemProvider(
+        IApplicationPaths applicationPaths,
+        ILogger<ImdbRatingsItemProvider> logger)
+    {
+        ArgumentNullException.ThrowIfNull(applicationPaths);
+
+        _logger = logger;
+        _indexCache = ImdbRatingsIndexCache.GetShared(
+            ImdbRatingsIndex.GetIndexPath(applicationPaths.DataPath),
+            logger);
+    }
+
+    /// <inheritdoc />
+    public string Name => "IMDb Ratings";
+
+    /// <inheritdoc />
+    public Task<ItemUpdateType> FetchAsync(Movie item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        => ApplyRatingAsync(item, config => config.IncludeMovies, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<ItemUpdateType> FetchAsync(Series item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        => ApplyRatingAsync(item, config => config.IncludeSeries, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<ItemUpdateType> FetchAsync(Episode item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        => ApplyRatingAsync(item, config => config.IncludeSeries, cancellationToken);
+
+    private async Task<ItemUpdateType> ApplyRatingAsync(
+        BaseItem item,
+        Func<PluginConfiguration, bool> isTypeEnabled,
+        CancellationToken cancellationToken)
+    {
+        if (item is null)
+        {
+            return ItemUpdateType.None;
+        }
+
+        var config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+
+        if (!config.EnableMetadataProvider)
+        {
+            // Release the shared index if the setting was turned off while the server was running.
+            _indexCache.Invalidate();
+            return ItemUpdateType.None;
+        }
+
+        if (!isTypeEnabled(config))
+        {
+            return ItemUpdateType.None;
+        }
+
+        var imdbId = item.GetProviderId(MetadataProvider.Imdb);
+        if (string.IsNullOrWhiteSpace(imdbId))
+        {
+            return ItemUpdateType.None;
+        }
+
+        var index = await _indexCache.GetIndexAsync(cancellationToken).ConfigureAwait(false);
+        if (index is null)
+        {
+            return ItemUpdateType.None;
+        }
+
+        if (!index.TryGetRating(imdbId, config.MinimumVotes, out var rating, out var votes))
+        {
+            return ItemUpdateType.None;
+        }
+
+        // Match the scheduled task's tolerance so the two paths agree on what counts as a change.
+        if (item.CommunityRating.HasValue && Math.Abs(item.CommunityRating.Value - rating) < 0.01f)
+        {
+            return ItemUpdateType.None;
+        }
+
+        if (config.EnableItemDebugLogging && _logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Applying IMDb rating {Rating} ({Votes} votes) to \"{Name}\" ({ImdbId}) at scan time",
+                rating,
+                votes,
+                item.Name,
+                imdbId);
+        }
+
+        item.CommunityRating = rating;
+        return ItemUpdateType.MetadataDownload;
+    }
+}

--- a/Providers/ImdbRatingsParser.cs
+++ b/Providers/ImdbRatingsParser.cs
@@ -47,15 +47,18 @@ public class ImdbRatingsParser
         return await ParseInternalAsync(filePath, includeIds, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<Dictionary<string, (float Rating, int Votes)>> ParseInternalAsync(
+    /// <summary>
+    /// Streams the IMDb TSV file, invoking <paramref name="onRow"/> for every row that parses cleanly.
+    /// </summary>
+    /// <remarks>
+    /// Callers own whatever they accumulate, so this is the single place TSV framing, header validation
+    /// and per-field parsing live regardless of whether the result is a dictionary or a compact index.
+    /// </remarks>
+    private async Task<ScanStats> ScanAsync(
         string filePath,
-        IReadOnlySet<string>? includeIds,
+        RowHandler onRow,
         CancellationToken cancellationToken)
     {
-        var initialCapacity = includeIds is null ? 1_200_000 : Math.Max(includeIds.Count, 16);
-        var ratings = new Dictionary<string, (float Rating, int Votes)>(initialCapacity);
-        HashSet<ulong>? includeNumericIds = includeIds is null ? null : BuildNumericIdSet(includeIds);
-
         using var stream = new FileStream(
             filePath,
             new FileStreamOptions
@@ -150,37 +153,7 @@ public class ImdbRatingsParser
                 $"IMDb ratings file has an invalid or missing header: \"{"(empty file)"}\"");
         }
 
-        if (includeIds is null)
-        {
-            _logger.LogInformation("Parsed {ValidRows} IMDb ratings from {Total} rows ({Errors} parse errors)",
-                ratings.Count, lineCount, parseErrors);
-        }
-        else
-        {
-            _logger.LogInformation(
-                "Parsed {MatchedRows} matching IMDb ratings from {ValidRows} valid rows in {Total} rows ({Errors} parse errors)",
-                ratings.Count, validRows, lineCount, parseErrors);
-        }
-
-        // Post-parse sanity checks
-        if (validRows == 0)
-        {
-            throw new InvalidDataException("IMDb ratings file contains header but no valid data rows.");
-        }
-
-        if (validRows < MinExpectedRows)
-        {
-            throw new InvalidDataException(
-                $"IMDb ratings file appears truncated: only {validRows} valid rows (expected at least {MinExpectedRows}).");
-        }
-
-        if (lineCount > 0 && (double)parseErrors / lineCount > MaxParseErrorRatio)
-        {
-            throw new InvalidDataException(
-                $"IMDb ratings file appears corrupt: {parseErrors} parse errors out of {lineCount} rows ({(double)parseErrors / lineCount:P1}).");
-        }
-
-        return ratings;
+        return new ScanStats(lineCount, validRows, parseErrors);
 
         void ProcessLine(ReadOnlySpan<byte> lineBytes)
         {
@@ -222,21 +195,130 @@ public class ImdbRatingsParser
             }
 
             validRows++;
-
-            if (includeIds is null)
-            {
-                ratings[Encoding.ASCII.GetString(tconstBytes)] = (rating, votes);
-                return;
-            }
-
-            if (includeNumericIds is not null
-                && TryParseImdbIdNumber(tconstBytes, out var imdbIdNumber)
-                && includeNumericIds.Contains(imdbIdNumber))
-            {
-                ratings[Encoding.ASCII.GetString(tconstBytes)] = (rating, votes);
-            }
+            onRow(tconstBytes, rating, votes);
         }
     }
+
+    private async Task<Dictionary<string, (float Rating, int Votes)>> ParseInternalAsync(
+        string filePath,
+        IReadOnlySet<string>? includeIds,
+        CancellationToken cancellationToken)
+    {
+        var initialCapacity = includeIds is null ? 1_200_000 : Math.Max(includeIds.Count, 16);
+        var ratings = new Dictionary<string, (float Rating, int Votes)>(initialCapacity);
+        HashSet<ulong>? includeNumericIds = includeIds is null ? null : BuildNumericIdSet(includeIds);
+
+        var stats = await ScanAsync(
+            filePath,
+            (tconstBytes, rating, votes) =>
+            {
+                if (includeNumericIds is null)
+                {
+                    ratings[Encoding.ASCII.GetString(tconstBytes)] = (rating, votes);
+                    return;
+                }
+
+                if (TryParseImdbIdNumber(tconstBytes, out var imdbIdNumber)
+                    && includeNumericIds.Contains(imdbIdNumber))
+                {
+                    ratings[Encoding.ASCII.GetString(tconstBytes)] = (rating, votes);
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        if (includeIds is null)
+        {
+            _logger.LogInformation("Parsed {ValidRows} IMDb ratings from {Total} rows ({Errors} parse errors)",
+                ratings.Count, stats.LineCount, stats.ParseErrors);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Parsed {MatchedRows} matching IMDb ratings from {ValidRows} valid rows in {Total} rows ({Errors} parse errors)",
+                ratings.Count, stats.ValidRows, stats.LineCount, stats.ParseErrors);
+        }
+
+        ValidateScan(stats);
+
+        return ratings;
+    }
+
+    /// <summary>
+    /// Parses the IMDb TSV file directly into a compact, sorted <see cref="ImdbRatingsIndex"/>.
+    /// </summary>
+    /// <remarks>
+    /// This never materialises the string-keyed dictionary, so peak memory stays proportional to the index
+    /// itself rather than to 1.7 million interned tconst strings.
+    /// </remarks>
+    public async Task<ImdbRatingsIndex> BuildIndexAsync(string filePath, CancellationToken cancellationToken)
+    {
+        const int InitialCapacity = 1_800_000;
+
+        var ids = new List<uint>(InitialCapacity);
+        var ratings = new List<byte>(InitialCapacity);
+        var votes = new List<uint>(InitialCapacity);
+        int skippedUnrepresentable = 0;
+
+        var stats = await ScanAsync(
+            filePath,
+            (tconstBytes, rating, voteCount) =>
+            {
+                if (!TryParseImdbIdNumber(tconstBytes, out var imdbIdNumber)
+                    || imdbIdNumber > uint.MaxValue
+                    || voteCount < 0)
+                {
+                    skippedUnrepresentable++;
+                    return;
+                }
+
+                ids.Add((uint)imdbIdNumber);
+                ratings.Add(ImdbRatingsIndex.EncodeRating(rating));
+                votes.Add((uint)voteCount);
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Indexed {IndexedRows} IMDb ratings from {Total} rows ({Errors} parse errors, {Skipped} unrepresentable IDs)",
+            ids.Count, stats.LineCount, stats.ParseErrors, skippedUnrepresentable);
+
+        ValidateScan(stats);
+
+        // ValidateScan only sees rows that framed and parsed correctly, which says nothing about whether their
+        // tconst values were usable. Without this a well-formed file full of unusable IDs would yield a valid
+        // but near-empty index and overwrite a good one.
+        if (ids.Count < MinExpectedRows)
+        {
+            throw new InvalidDataException(
+                $"IMDb ratings file yielded only {ids.Count} indexable rows (expected at least {MinExpectedRows}); "
+                + $"{skippedUnrepresentable} of {stats.ValidRows} valid rows had unusable IMDb IDs.");
+        }
+
+        return ImdbRatingsIndex.CreateSorted(ids.ToArray(), ratings.ToArray(), votes.ToArray());
+    }
+
+    private static void ValidateScan(ScanStats stats)
+    {
+        if (stats.ValidRows == 0)
+        {
+            throw new InvalidDataException("IMDb ratings file contains header but no valid data rows.");
+        }
+
+        if (stats.ValidRows < MinExpectedRows)
+        {
+            throw new InvalidDataException(
+                $"IMDb ratings file appears truncated: only {stats.ValidRows} valid rows (expected at least {MinExpectedRows}).");
+        }
+
+        if (stats.LineCount > 0 && (double)stats.ParseErrors / stats.LineCount > MaxParseErrorRatio)
+        {
+            throw new InvalidDataException(
+                $"IMDb ratings file appears corrupt: {stats.ParseErrors} parse errors out of {stats.LineCount} rows ({(double)stats.ParseErrors / stats.LineCount:P1}).");
+        }
+    }
+
+    private delegate void RowHandler(ReadOnlySpan<byte> tconstBytes, float rating, int votes);
+
+    private readonly record struct ScanStats(int LineCount, int ValidRows, int ParseErrors);
 
     private static string DecodeHeaderForError(ReadOnlySpan<byte> headerBytes)
     {
@@ -278,7 +360,13 @@ public class ImdbRatingsParser
                 return false;
             }
 
-            numericId = (numericId * 10) + (ulong)(c - '0');
+            ulong digit = (ulong)(c - '0');
+            if (numericId > (ulong.MaxValue - digit) / 10)
+            {
+                return false;
+            }
+
+            numericId = (numericId * 10) + digit;
         }
 
         return true;
@@ -301,7 +389,13 @@ public class ImdbRatingsParser
                 return false;
             }
 
-            numericId = (numericId * 10) + (ulong)(c - (byte)'0');
+            ulong digit = (ulong)(c - (byte)'0');
+            if (numericId > (ulong.MaxValue - digit) / 10)
+            {
+                return false;
+            }
+
+            numericId = (numericId * 10) + digit;
         }
 
         return true;

--- a/ScheduledTasks/RefreshImdbRatingsTask.cs
+++ b/ScheduledTasks/RefreshImdbRatingsTask.cs
@@ -65,12 +65,28 @@ public class RefreshImdbRatingsTask : IScheduledTask
         _logger.LogInformation("Starting IMDb ratings refresh (minVotes={MinVotes}, movies={Movies}, series={Series}, seasonAverages={SeasonAverages})",
             config.MinimumVotes, config.IncludeMovies, config.IncludeSeries, config.IncludeSeasonAverages);
 
+        // Reclaim the provider's disk and memory before any network, parsing, or library work can fail. The
+        // scheduled rating refresh remains enabled independently and continues below.
+        if (!IsMetadataProviderCurrentlyEnabled(config))
+        {
+            DisableProviderIndex();
+        }
+
+        var downloader = new ImdbFlatFileDownloader(
+            _httpClientFactory,
+            _loggerFactory.CreateLogger<ImdbFlatFileDownloader>(),
+            _dataPath);
+        var parser = new ImdbRatingsParser(_loggerFactory.CreateLogger<ImdbRatingsParser>());
+
         // Step 1: Query library items and build a distinct IMDb ID filter set.
         progress.Report(0);
         var items = GetLibraryItems(config);
         if (items.Count == 0)
         {
             _logger.LogInformation("Found 0 library items with IMDb IDs");
+
+            // An empty library still needs an index built, so the provider can rate the very first scan.
+            await TryWriteProviderIndexAsync(downloader, parser, config, cancellationToken).ConfigureAwait(false);
             progress.Report(100);
             return;
         }
@@ -93,6 +109,8 @@ public class RefreshImdbRatingsTask : IScheduledTask
         if (libraryImdbIds.Count == 0)
         {
             _logger.LogWarning("No valid IMDb IDs found on selected library items — nothing to update");
+
+            await TryWriteProviderIndexAsync(downloader, parser, config, cancellationToken).ConfigureAwait(false);
             progress.Report(100);
             return;
         }
@@ -100,12 +118,6 @@ public class RefreshImdbRatingsTask : IScheduledTask
         progress.Report(5);
 
         // Step 2: Download/cache the ratings file, Step 3: Parse ratings (filtered to library IMDb IDs)
-        var downloader = new ImdbFlatFileDownloader(
-            _httpClientFactory,
-            _loggerFactory.CreateLogger<ImdbFlatFileDownloader>(),
-            _dataPath);
-        var parser = new ImdbRatingsParser(_loggerFactory.CreateLogger<ImdbRatingsParser>());
-
         var ratings = await DownloadAndParseWithRetryAsync(
             downloader,
             parser,
@@ -328,6 +340,9 @@ public class RefreshImdbRatingsTask : IScheduledTask
             }
         }
 
+        // Step 6: Refresh the compact index the scan-time metadata provider reads.
+        await TryWriteProviderIndexAsync(downloader, parser, config, cancellationToken).ConfigureAwait(false);
+
         progress.Report(100);
         var skippedTotal = skippedMissingImdbId + skippedBelowMinimumVotes + skippedUnchanged;
         _logger.LogInformation(
@@ -339,6 +354,73 @@ public class RefreshImdbRatingsTask : IScheduledTask
             skippedBelowMinimumVotes,
             skippedMissingImdbId,
             notFound);
+    }
+
+    /// <summary>
+    /// Rebuilds the compact index used by <see cref="Providers.ImdbRatingsItemProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// The index is an enhancement rather than part of the refresh contract, so any failure here is logged
+    /// and swallowed: the ratings written above are already committed and must not be reported as failed.
+    /// The stale index stays in place until the next successful run.
+    /// </remarks>
+    private async Task TryWriteProviderIndexAsync(
+        ImdbFlatFileDownloader downloader,
+        ImdbRatingsParser parser,
+        PluginConfiguration config,
+        CancellationToken cancellationToken)
+    {
+        var indexPath = ImdbRatingsIndex.GetIndexPath(_dataPath);
+
+        if (!IsMetadataProviderCurrentlyEnabled(config))
+        {
+            // The setting may have changed while the scheduled refresh was running.
+            DisableProviderIndex();
+            return;
+        }
+
+        try
+        {
+            // The task is the sole writer of the index and may download to build it; the provider never does.
+            var ratingsFilePath = await GetRatingsFilePathWithTransientRetryAsync(downloader, cancellationToken)
+                .ConfigureAwait(false);
+
+            var index = await parser.BuildIndexAsync(ratingsFilePath, cancellationToken).ConfigureAwait(false);
+
+            // Building can take long enough for the setting to change. Avoid publishing work that was disabled
+            // while the task was running.
+            if (!IsMetadataProviderCurrentlyEnabled(config))
+            {
+                DisableProviderIndex();
+                return;
+            }
+
+            await index.WriteAsync(indexPath, cancellationToken).ConfigureAwait(false);
+
+            // If disable raced the asynchronous write, the configuration callback deleted the old destination
+            // before File.Move published this one. Delete the newly published file as the later operation.
+            if (!IsMetadataProviderCurrentlyEnabled(config))
+            {
+                DisableProviderIndex();
+                return;
+            }
+
+            ImdbRatingsIndexCache.InvalidateShared();
+
+            _logger.LogInformation(
+                "Wrote IMDb ratings index: {Count} titles, {SizeMb:F1} MB at {Path}",
+                index.Count,
+                index.ApproximateSizeInBytes / (1024d * 1024d),
+                indexPath);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to build IMDb ratings index; scan-time ratings will use the previous index if present");
+        }
     }
 
     private async Task<Dictionary<string, (float Rating, int Votes)>> DownloadAndParseWithRetryAsync(
@@ -379,7 +461,10 @@ public class RefreshImdbRatingsTask : IScheduledTask
     {
         try
         {
-            var filePath = await downloader.GetRatingsFilePathAsync(cancellationToken).ConfigureAwait(false);
+            // Cache invalidation above forces a fresh download. Use the same timeout-aware retry path as the
+            // initial attempt so an exhausted HttpClient timeout is reported as failure, not cancellation.
+            var filePath = await GetRatingsFilePathWithTransientRetryAsync(downloader, cancellationToken)
+                .ConfigureAwait(false);
             progress.Report(10);
             return await parser.ParseFilteredAsync(filePath, includeImdbIds, cancellationToken).ConfigureAwait(false);
         }
@@ -398,7 +483,7 @@ public class RefreshImdbRatingsTask : IScheduledTask
         {
             return await downloader.GetRatingsFilePathAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (IsTransientNetworkError(ex))
+        catch (Exception ex) when (IsTransientNetworkError(ex, cancellationToken))
         {
             // Transient download error — try once more after a short delay, or fall back to stale cache.
             _logger.LogWarning(ex, "Transient network error downloading IMDb ratings; retrying once after delay");
@@ -409,11 +494,21 @@ public class RefreshImdbRatingsTask : IScheduledTask
             {
                 return await downloader.GetRatingsFilePathAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception retryEx) when (IsTransientNetworkError(retryEx))
+            catch (Exception retryEx) when (IsTransientNetworkError(retryEx, cancellationToken))
             {
                 if (!downloader.HasCacheFile)
                 {
                     _logger.LogError(retryEx, "Download failed after retry and no cached ratings file exists");
+
+                    // HttpClient represents its own timeout as TaskCanceledException. Jellyfin treats every
+                    // OperationCanceledException as a user-cancelled scheduled task, so translate an exhausted
+                    // timeout when the scheduler token itself remains active.
+                    if (retryEx is OperationCanceledException timeoutException
+                        && !cancellationToken.IsCancellationRequested)
+                    {
+                        throw CreateExhaustedTimeoutException(timeoutException);
+                    }
+
                     throw;
                 }
 
@@ -425,10 +520,51 @@ public class RefreshImdbRatingsTask : IScheduledTask
         }
     }
 
-    private static bool IsTransientNetworkError(Exception ex)
+    internal static bool IsTransientNetworkError(Exception ex, CancellationToken cancellationToken)
     {
         return ex is HttpRequestException
-            || (ex is IOException && ex is not InvalidDataException);
+            || (ex is IOException && ex is not InvalidDataException)
+            || (ex is OperationCanceledException && !cancellationToken.IsCancellationRequested);
+    }
+
+    internal static bool ResolveMetadataProviderEnabled(
+        PluginConfiguration taskConfiguration,
+        PluginConfiguration? currentConfiguration)
+    {
+        ArgumentNullException.ThrowIfNull(taskConfiguration);
+        return (currentConfiguration ?? taskConfiguration).EnableMetadataProvider;
+    }
+
+    internal static HttpRequestException CreateExhaustedTimeoutException(OperationCanceledException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return new HttpRequestException("IMDb ratings download timed out after retry.", exception);
+    }
+
+    private static bool IsMetadataProviderCurrentlyEnabled(PluginConfiguration taskConfiguration)
+    {
+        return ResolveMetadataProviderEnabled(taskConfiguration, Plugin.Instance?.Configuration);
+    }
+
+    private void DisableProviderIndex()
+    {
+        var indexPath = ImdbRatingsIndex.GetIndexPath(_dataPath);
+
+        try
+        {
+            if (File.Exists(indexPath))
+            {
+                File.Delete(indexPath);
+                _logger.LogInformation("Scan-time provider disabled; removed IMDb ratings index at {Path}", indexPath);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.LogWarning(ex, "Failed to remove IMDb ratings index at {Path}", indexPath);
+        }
+
+        // Drop the loaded copy even if disk cleanup failed; a disabled provider must not retain its memory.
+        ImdbRatingsIndexCache.InvalidateShared();
     }
 
     private IReadOnlyList<BaseItem> GetLibraryItems(PluginConfiguration config)

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexBuildTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexBuildTests.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using Jellyfin.Plugin.ImdbRatings.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+public class ImdbRatingsIndexBuildTests
+{
+    // Matches ImdbRatingsParser.MinExpectedRows; the parser rejects anything smaller as truncated.
+    private const int MinExpectedRows = 500_000;
+
+    [Fact]
+    public async Task BuildIndexAsync_WellFormedFile_IndexesEveryRow()
+    {
+        string path = CreateTempFilePath();
+        try
+        {
+            await WriteRatingsFileAsync(path, MinExpectedRows, id => $"tt{id:0000000}");
+
+            var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+            var index = await parser.BuildIndexAsync(path, CancellationToken.None);
+
+            Assert.Equal(MinExpectedRows, index.Count);
+
+            Assert.True(index.TryGetRating("tt0000001", 0, out var first, out var firstVotes));
+            Assert.Equal(ExpectedRating(1), first, 3);
+            Assert.Equal(ExpectedVotes(1), firstVotes);
+
+            Assert.True(index.TryGetRating($"tt{MinExpectedRows:0000000}", 0, out var last, out _));
+            Assert.Equal(ExpectedRating(MinExpectedRows), last, 3);
+        }
+        finally
+        {
+            TryDeleteFile(path);
+        }
+    }
+
+    [Fact]
+    public async Task BuildIndexAsync_WellFormedFileWithUnusableIds_ThrowsRatherThanWritingAnEmptyIndex()
+    {
+        // Every row frames and parses correctly, so the scan-level validation is satisfied, but no tconst is
+        // usable. Without the indexable-row check this would produce a valid, empty index that overwrites a
+        // good one on disk.
+        string path = CreateTempFilePath();
+        try
+        {
+            await WriteRatingsFileAsync(path, MinExpectedRows, id => $"xx{id:0000000}");
+
+            var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+
+            var ex = await Assert.ThrowsAsync<InvalidDataException>(
+                () => parser.BuildIndexAsync(path, CancellationToken.None));
+
+            Assert.Contains("indexable rows", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteFile(path);
+        }
+    }
+
+    [Fact]
+    public async Task BuildIndexAsync_IdsTooWideOrLongForNumericTypes_AreSkipped()
+    {
+        string path = CreateTempFilePath();
+        try
+        {
+            // One row is beyond uint range and one is 2^64, which used to wrap to zero in the ulong parser.
+            // The rest are ordinary. The row count stays above the
+            // indexable-row floor so this exercises skipping rather than the truncation guard.
+            const int rowCount = MinExpectedRows + 2;
+            await WriteRatingsFileAsync(
+                path,
+                rowCount,
+                id => id switch
+                {
+                    7 => "tt99999999999",
+                    8 => "tt18446744073709551616",
+                    _ => $"tt{id:0000000}"
+                });
+
+            var parser = new ImdbRatingsParser(NullLogger<ImdbRatingsParser>.Instance);
+            var index = await parser.BuildIndexAsync(path, CancellationToken.None);
+
+            Assert.Equal(rowCount - 2, index.Count);
+            Assert.False(index.TryGetRating("tt99999999999", 0, out _, out _));
+            Assert.False(index.TryGetRating("tt18446744073709551616", 0, out _, out _));
+            Assert.True(index.TryGetRating("tt0000009", 0, out _, out _));
+        }
+        finally
+        {
+            TryDeleteFile(path);
+        }
+    }
+
+    private static async Task WriteRatingsFileAsync(string path, int rowCount, Func<int, string> idFactory)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 128 * 1024, useAsync: true);
+        await using var writer = new StreamWriter(stream);
+        writer.NewLine = "\n";
+
+        await writer.WriteLineAsync("tconst\taverageRating\tnumVotes");
+
+        for (int i = 1; i <= rowCount; i++)
+        {
+            await writer.WriteLineAsync(string.Create(
+                CultureInfo.InvariantCulture,
+                $"{idFactory(i)}\t{ExpectedRating(i):0.0}\t{ExpectedVotes(i)}"));
+        }
+    }
+
+    private static float ExpectedRating(int index) => ((index % 90) + 10) / 10f;
+
+    private static int ExpectedVotes(int index) => 1000 + index;
+
+    private static string CreateTempFilePath()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "imdb-ratings-index-build-tests");
+        return Path.Combine(dir, $"{Guid.NewGuid():N}.tsv");
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for test temp files.
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexCacheTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexCacheTests.cs
@@ -1,0 +1,332 @@
+using Jellyfin.Plugin.ImdbRatings.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+public class ImdbRatingsIndexCacheTests
+{
+    [Fact]
+    public async Task GetIndexAsync_NoIndexOnDisk_ReturnsNull()
+    {
+        using var temp = new TempDirectory();
+        var cache = new ImdbRatingsIndexCache(temp.PathFor("title.ratings.idx"), NullLogger.Instance);
+
+        Assert.Null(await cache.GetIndexAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetIndexAsync_AbsentIndex_IsNegativelyCachedUntilInvalidated()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        var cache = new ImdbRatingsIndexCache(indexPath, NullLogger.Instance);
+
+        Assert.Null(await cache.GetIndexAsync(CancellationToken.None));
+
+        await WriteIndexAsync(indexPath);
+
+        // Still null: the miss is cached for the recheck interval, so a scan over a server with no index
+        // does not stat the file once per item.
+        Assert.Null(await cache.GetIndexAsync(CancellationToken.None));
+
+        cache.Invalidate();
+
+        var loaded = await cache.GetIndexAsync(CancellationToken.None);
+        Assert.NotNull(loaded);
+        Assert.Equal(2, loaded!.Count);
+    }
+
+    [Fact]
+    public async Task GetIndexAsync_CorruptIndex_ReturnsNullAndDoesNotThrow()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        await File.WriteAllBytesAsync(indexPath, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+
+        var cache = new ImdbRatingsIndexCache(indexPath, NullLogger.Instance);
+
+        Assert.Null(await cache.GetIndexAsync(CancellationToken.None));
+        Assert.Null(await cache.GetIndexAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetIndexAsync_LoadedIndex_IsServedFromMemoryAfterFileRemoval()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        await WriteIndexAsync(indexPath);
+
+        var cache = new ImdbRatingsIndexCache(indexPath, NullLogger.Instance);
+        Assert.NotNull(await cache.GetIndexAsync(CancellationToken.None));
+
+        File.Delete(indexPath);
+
+        // Within the recheck interval the loaded copy keeps serving rather than re-statting per item.
+        Assert.NotNull(await cache.GetIndexAsync(CancellationToken.None));
+
+        cache.Invalidate();
+        Assert.Null(await cache.GetIndexAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetIndexAsync_ConcurrentInitialCallers_WaitForOneLoad()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        await WriteIndexAsync(indexPath);
+
+        var loadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLoad = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int loadCount = 0;
+        var cache = new ImdbRatingsIndexCache(
+            indexPath,
+            NullLogger.Instance,
+            async (path, cancellationToken) =>
+            {
+                Interlocked.Increment(ref loadCount);
+                loadStarted.TrySetResult();
+                await releaseLoad.Task.WaitAsync(cancellationToken);
+                return await ImdbRatingsIndex.TryLoadAsync(path, cancellationToken);
+            });
+
+        var first = cache.GetIndexAsync(CancellationToken.None);
+        await loadStarted.Task;
+
+        var second = cache.GetIndexAsync(CancellationToken.None);
+        Assert.False(second.IsCompleted);
+
+        releaseLoad.SetResult();
+
+        Assert.NotNull(await first);
+        Assert.NotNull(await second);
+        Assert.Equal(1, loadCount);
+    }
+
+    [Fact]
+    public async Task GetIndexAsync_CanceledLoad_DoesNotPoisonObservedWriteTime()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        await WriteIndexAsync(indexPath);
+
+        var firstLoadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int loadCount = 0;
+        var cache = new ImdbRatingsIndexCache(
+            indexPath,
+            NullLogger.Instance,
+            async (path, cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref loadCount) == 1)
+                {
+                    firstLoadStarted.SetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+
+                return await ImdbRatingsIndex.TryLoadAsync(path, cancellationToken);
+            });
+
+        using var cancellation = new CancellationTokenSource();
+        var canceledLoad = cache.GetIndexAsync(cancellation.Token);
+        await firstLoadStarted.Task;
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledLoad);
+
+        var retried = await cache.GetIndexAsync(CancellationToken.None);
+        Assert.NotNull(retried);
+        Assert.Equal(2, loadCount);
+    }
+
+    [Fact]
+    public async Task Invalidate_DuringLoad_RetriesCurrentGenerationWithoutRepopulatingOldOne()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        await WriteIndexAsync(indexPath);
+
+        var firstLoadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstLoad = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int loadCount = 0;
+        var cache = new ImdbRatingsIndexCache(
+            indexPath,
+            NullLogger.Instance,
+            async (path, cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref loadCount) == 1)
+                {
+                    firstLoadStarted.SetResult();
+                    await releaseFirstLoad.Task.WaitAsync(cancellationToken);
+                }
+
+                return await ImdbRatingsIndex.TryLoadAsync(path, cancellationToken);
+            });
+
+        var invalidatedLoad = cache.GetIndexAsync(CancellationToken.None);
+        await firstLoadStarted.Task;
+
+        cache.Invalidate();
+        releaseFirstLoad.SetResult();
+
+        Assert.NotNull(await invalidatedLoad);
+        Assert.NotNull(await cache.GetIndexAsync(CancellationToken.None));
+        Assert.Equal(2, loadCount);
+    }
+
+    [Fact]
+    public async Task GetIndexAsync_TransientIoFailure_PreservesLastGoodIndexAndRetriesChangedFile()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        await WriteIndexAsync(indexPath, 5.7f);
+
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow);
+        int loadCount = 0;
+        var cache = new ImdbRatingsIndexCache(
+            indexPath,
+            NullLogger.Instance,
+            async (path, cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref loadCount) == 2)
+                {
+                    throw new IOException("Simulated transient read failure.");
+                }
+
+                return await ImdbRatingsIndex.TryLoadAsync(path, cancellationToken);
+            },
+            timeProvider);
+
+        var first = await cache.GetIndexAsync(CancellationToken.None);
+        AssertRating(first, 5.7f);
+
+        var oldWriteTime = File.GetLastWriteTimeUtc(indexPath);
+        await WriteIndexAsync(indexPath, 9.1f);
+        File.SetLastWriteTimeUtc(indexPath, oldWriteTime.AddSeconds(5));
+        timeProvider.Advance(TimeSpan.FromSeconds(61));
+
+        var fallback = await cache.GetIndexAsync(CancellationToken.None);
+        AssertRating(fallback, 5.7f);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(61));
+        var retried = await cache.GetIndexAsync(CancellationToken.None);
+        AssertRating(retried, 9.1f);
+        Assert.Equal(3, loadCount);
+    }
+
+    [Fact]
+    public async Task GetIndexAsync_TransientStatFailure_PreservesLastGoodIndexAndRetriesChangedFile()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+        await WriteIndexAsync(indexPath, 5.7f);
+
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow);
+        int statCount = 0;
+        int loadCount = 0;
+        var cache = new ImdbRatingsIndexCache(
+            indexPath,
+            NullLogger.Instance,
+            async (path, cancellationToken) =>
+            {
+                Interlocked.Increment(ref loadCount);
+                return await ImdbRatingsIndex.TryLoadAsync(path, cancellationToken);
+            },
+            timeProvider,
+            path =>
+            {
+                if (Interlocked.Increment(ref statCount) == 2)
+                {
+                    throw new IOException("Simulated transient stat failure.");
+                }
+
+                return File.GetLastWriteTimeUtc(path);
+            });
+
+        var first = await cache.GetIndexAsync(CancellationToken.None);
+        AssertRating(first, 5.7f);
+
+        var oldWriteTime = File.GetLastWriteTimeUtc(indexPath);
+        await WriteIndexAsync(indexPath, 9.1f);
+        File.SetLastWriteTimeUtc(indexPath, oldWriteTime.AddSeconds(5));
+        timeProvider.Advance(TimeSpan.FromSeconds(61));
+
+        var fallback = await cache.GetIndexAsync(CancellationToken.None);
+        AssertRating(fallback, 5.7f);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(61));
+        var retried = await cache.GetIndexAsync(CancellationToken.None);
+        AssertRating(retried, 9.1f);
+        Assert.Equal(3, statCount);
+        Assert.Equal(2, loadCount);
+    }
+
+    [Fact]
+    public void GetShared_SamePath_ReturnsOneInstance()
+    {
+        using var temp = new TempDirectory();
+        var indexPath = temp.PathFor("title.ratings.idx");
+
+        var first = ImdbRatingsIndexCache.GetShared(indexPath, NullLogger.Instance);
+        var second = ImdbRatingsIndexCache.GetShared(indexPath, NullLogger.Instance);
+
+        Assert.Same(first, second);
+    }
+
+    private static async Task WriteIndexAsync(string indexPath, float firstRating = 5.7f)
+    {
+        var index = ImdbRatingsIndex.CreateSorted(
+            new uint[] { 2, 1 },
+            new byte[] { 80, ImdbRatingsIndex.EncodeRating(firstRating) },
+            new uint[] { 200, 100 });
+
+        await index.WriteAsync(indexPath, CancellationToken.None);
+    }
+
+    private static void AssertRating(ImdbRatingsIndex? index, float expected)
+    {
+        Assert.NotNull(index);
+        Assert.True(index!.TryGetRating("tt0000001", 0, out var rating, out _));
+        Assert.Equal(expected, rating, 3);
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public ManualTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan amount)
+        {
+            _utcNow += amount;
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        private readonly string _path;
+
+        public TempDirectory()
+        {
+            _path = Path.Combine(Path.GetTempPath(), "imdb-ratings-cache-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_path);
+        }
+
+        public string PathFor(string fileName) => Path.Combine(_path, fileName);
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_path, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup for test temp directories.
+            }
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/ImdbRatingsIndexTests.cs
@@ -1,0 +1,319 @@
+using Jellyfin.Plugin.ImdbRatings.Providers;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+public class ImdbRatingsIndexTests
+{
+    private static ImdbRatingsIndex CreateIndex(params (uint Id, float Rating, uint Votes)[] rows)
+    {
+        var ids = new uint[rows.Length];
+        var ratings = new byte[rows.Length];
+        var votes = new uint[rows.Length];
+
+        for (int i = 0; i < rows.Length; i++)
+        {
+            ids[i] = rows[i].Id;
+            ratings[i] = ImdbRatingsIndex.EncodeRating(rows[i].Rating);
+            votes[i] = rows[i].Votes;
+        }
+
+        return ImdbRatingsIndex.CreateSorted(ids, ratings, votes);
+    }
+
+    [Theory]
+    [InlineData(1.0f, 10)]
+    [InlineData(7.3f, 73)]
+    [InlineData(9.9f, 99)]
+    [InlineData(10.0f, 100)]
+    public void EncodeRating_SingleDecimalValues_RoundTripExactly(float rating, byte expected)
+    {
+        Assert.Equal(expected, ImdbRatingsIndex.EncodeRating(rating));
+    }
+
+    [Fact]
+    public void EncodeRating_RoundsHalfAwayFromZero()
+    {
+        // 7.25 is not a value IMDb publishes, but the encoder must not silently truncate.
+        Assert.Equal(73, ImdbRatingsIndex.EncodeRating(7.25f));
+    }
+
+    [Theory]
+    [InlineData("tt0000001", 1u)]
+    [InlineData("tt9916880", 9916880u)]
+    [InlineData("tt43858878", 43858878u)]
+    public void TryParseImdbId_ValidIds_ReturnsNumericForm(string imdbId, uint expected)
+    {
+        Assert.True(ImdbRatingsIndex.TryParseImdbId(imdbId, out var numericId));
+        Assert.Equal(expected, numericId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("tt")]
+    [InlineData("nm0000001")]
+    [InlineData("tt00x0001")]
+    [InlineData("0000001")]
+    [InlineData("tt99999999999")]
+    [InlineData("tt18446744073709551616")]
+    public void TryParseImdbId_InvalidOrOversizedIds_ReturnsFalse(string? imdbId)
+    {
+        Assert.False(ImdbRatingsIndex.TryParseImdbId(imdbId, out _));
+    }
+
+    [Fact]
+    public void CreateSorted_UnsortedInput_KeepsRowsTogether()
+    {
+        // The IMDb flat file is byte-sorted, not numerically sorted: tt10001002 precedes tt9916850 in the
+        // source. CreateSorted must reorder the keys and carry each row's rating and votes along with them.
+        var index = CreateIndex(
+            (10001002u, 6.1f, 500),
+            (9916850u, 8.4f, 1200),
+            (1u, 5.7f, 2224));
+
+        Assert.Equal(3, index.Count);
+
+        Assert.True(index.TryGetRating("tt10001002", 1, out var first, out var firstVotes));
+        Assert.Equal(6.1f, first, 3);
+        Assert.Equal(500, firstVotes);
+
+        Assert.True(index.TryGetRating("tt9916850", 1, out var second, out var secondVotes));
+        Assert.Equal(8.4f, second, 3);
+        Assert.Equal(1200, secondVotes);
+
+        Assert.True(index.TryGetRating("tt0000001", 1, out var third, out var thirdVotes));
+        Assert.Equal(5.7f, third, 3);
+        Assert.Equal(2224, thirdVotes);
+    }
+
+    [Fact]
+    public void TryGetRating_MissingId_ReturnsFalse()
+    {
+        var index = CreateIndex((10u, 7.0f, 100), (20u, 8.0f, 200), (30u, 9.0f, 300));
+
+        Assert.False(index.TryGetRating("tt0000015", 1, out _, out _));
+    }
+
+    [Fact]
+    public void TryGetRating_FirstAndLastEntries_AreFound()
+    {
+        var index = CreateIndex((10u, 7.0f, 100), (20u, 8.0f, 200), (30u, 9.0f, 300));
+
+        Assert.True(index.TryGetRating("tt0000010", 1, out var first, out _));
+        Assert.Equal(7.0f, first, 3);
+
+        Assert.True(index.TryGetRating("tt0000030", 1, out var last, out _));
+        Assert.Equal(9.0f, last, 3);
+    }
+
+    [Fact]
+    public void TryGetRating_BelowMinimumVotes_ReturnsFalse()
+    {
+        var index = CreateIndex((10u, 9.4f, 11));
+
+        Assert.False(index.TryGetRating("tt0000010", 1000, out _, out _));
+        Assert.True(index.TryGetRating("tt0000010", 11, out var rating, out var votes));
+        Assert.Equal(9.4f, rating, 3);
+        Assert.Equal(11, votes);
+    }
+
+    [Fact]
+    public void TryGetRating_MalformedId_ReturnsFalse()
+    {
+        var index = CreateIndex((10u, 7.0f, 100));
+
+        Assert.False(index.TryGetRating("not-an-id", 1, out _, out _));
+        Assert.False(index.TryGetRating(null, 1, out _, out _));
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThenTryLoadAsync_RoundTripsAllRows()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var indexPath = Path.Combine(directory, "title.ratings.idx");
+            var index = CreateIndex(
+                (1u, 5.7f, 2224),
+                (43858878u, 10.0f, 3221521),
+                (9916880u, 1.0f, 5));
+
+            await index.WriteAsync(indexPath, CancellationToken.None);
+
+            var loaded = await ImdbRatingsIndex.TryLoadAsync(indexPath, CancellationToken.None);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(3, loaded!.Count);
+
+            Assert.True(loaded.TryGetRating("tt0000001", 1, out var a, out var aVotes));
+            Assert.Equal(5.7f, a, 3);
+            Assert.Equal(2224, aVotes);
+
+            Assert.True(loaded.TryGetRating("tt43858878", 1, out var b, out var bVotes));
+            Assert.Equal(10.0f, b, 3);
+            Assert.Equal(3221521, bVotes);
+
+            Assert.True(loaded.TryGetRating("tt9916880", 1, out var c, out var cVotes));
+            Assert.Equal(1.0f, c, 3);
+            Assert.Equal(5, cVotes);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WriteAsync_ReplacesExistingIndexAndLeavesNoTempFile()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var indexPath = Path.Combine(directory, "title.ratings.idx");
+
+            await CreateIndex((1u, 5.0f, 10)).WriteAsync(indexPath, CancellationToken.None);
+            await CreateIndex((1u, 6.0f, 20), (2u, 7.0f, 30)).WriteAsync(indexPath, CancellationToken.None);
+
+            var loaded = await ImdbRatingsIndex.TryLoadAsync(indexPath, CancellationToken.None);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(2, loaded!.Count);
+            Assert.True(loaded.TryGetRating("tt0000001", 1, out var rating, out _));
+            Assert.Equal(6.0f, rating, 3);
+            Assert.False(File.Exists(indexPath + ".tmp"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WriteAsync_ReplacesExistingIndexWhileProductionLoaderHoldsOldFileOpen()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var indexPath = Path.Combine(directory, "title.ratings.idx");
+            await CreateIndex((1u, 5.0f, 10)).WriteAsync(indexPath, CancellationToken.None);
+
+            var readerOpened = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseReader = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var oldLoad = ImdbRatingsIndex.TryLoadAsync(
+                indexPath,
+                CancellationToken.None,
+                async cancellationToken =>
+                {
+                    readerOpened.SetResult();
+                    await releaseReader.Task.WaitAsync(cancellationToken);
+                });
+
+            await readerOpened.Task;
+
+            try
+            {
+                await CreateIndex((1u, 9.0f, 20)).WriteAsync(indexPath, CancellationToken.None);
+            }
+            finally
+            {
+                releaseReader.TrySetResult();
+            }
+
+            var oldIndex = await oldLoad;
+            Assert.NotNull(oldIndex);
+            Assert.True(oldIndex!.TryGetRating("tt0000001", 0, out var oldRating, out _));
+            Assert.Equal(5.0f, oldRating, 3);
+
+            var replacement = await ImdbRatingsIndex.TryLoadAsync(indexPath, CancellationToken.None);
+            Assert.NotNull(replacement);
+            Assert.True(replacement!.TryGetRating("tt0000001", 0, out var rating, out _));
+            Assert.Equal(9.0f, rating, 3);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TryLoadAsync_MissingFile_ReturnsNull()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var result = await ImdbRatingsIndex.TryLoadAsync(
+                Path.Combine(directory, "absent.idx"),
+                CancellationToken.None);
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TryLoadAsync_TruncatedFile_ReturnsNull()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var indexPath = Path.Combine(directory, "title.ratings.idx");
+            await CreateIndex((1u, 5.0f, 10), (2u, 6.0f, 20)).WriteAsync(indexPath, CancellationToken.None);
+
+            var bytes = await File.ReadAllBytesAsync(indexPath);
+            await File.WriteAllBytesAsync(indexPath, bytes[..(bytes.Length - 4)]);
+
+            Assert.Null(await ImdbRatingsIndex.TryLoadAsync(indexPath, CancellationToken.None));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TryLoadAsync_WrongMagicOrVersion_ReturnsNull()
+    {
+        var directory = CreateTempDirectory();
+        try
+        {
+            var indexPath = Path.Combine(directory, "title.ratings.idx");
+            await CreateIndex((1u, 5.0f, 10)).WriteAsync(indexPath, CancellationToken.None);
+
+            var bytes = await File.ReadAllBytesAsync(indexPath);
+
+            var wrongMagic = bytes.ToArray();
+            wrongMagic[0] = (byte)'X';
+            await File.WriteAllBytesAsync(indexPath, wrongMagic);
+            Assert.Null(await ImdbRatingsIndex.TryLoadAsync(indexPath, CancellationToken.None));
+
+            var wrongVersion = bytes.ToArray();
+            wrongVersion[8] = (byte)(ImdbRatingsIndex.FormatVersion + 1);
+            await File.WriteAllBytesAsync(indexPath, wrongVersion);
+            Assert.Null(await ImdbRatingsIndex.TryLoadAsync(indexPath, CancellationToken.None));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetIndexPath_SitsBesideTheRatingsCache()
+    {
+        var path = ImdbRatingsIndex.GetIndexPath(Path.Combine("data", "root"));
+
+        Assert.Equal(
+            Path.Combine("data", "root", "imdb-ratings-cache", "title.ratings.idx"),
+            path);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "imdb-ratings-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/tests/Jellyfin.Plugin.ImdbRatings.Tests/RefreshImdbRatingsTaskTests.cs
+++ b/tests/Jellyfin.Plugin.ImdbRatings.Tests/RefreshImdbRatingsTaskTests.cs
@@ -1,0 +1,53 @@
+using Jellyfin.Plugin.ImdbRatings.Configuration;
+using Jellyfin.Plugin.ImdbRatings.ScheduledTasks;
+
+namespace Jellyfin.Plugin.ImdbRatings.Tests;
+
+public class RefreshImdbRatingsTaskTests
+{
+    [Fact]
+    public void IsTransientNetworkError_HttpTimeoutWithoutSchedulerCancellation_ReturnsTrue()
+    {
+        Assert.True(RefreshImdbRatingsTask.IsTransientNetworkError(
+            new TaskCanceledException("Simulated HTTP timeout."),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public void IsTransientNetworkError_SchedulerCancellation_ReturnsFalse()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.False(RefreshImdbRatingsTask.IsTransientNetworkError(
+            new OperationCanceledException(cancellation.Token),
+            cancellation.Token));
+    }
+
+    [Fact]
+    public void CreateExhaustedTimeoutException_ProducesNonCancellationFailure()
+    {
+        var timeout = new TaskCanceledException("Simulated HTTP timeout.");
+
+        var translated = RefreshImdbRatingsTask.CreateExhaustedTimeoutException(timeout);
+
+        Assert.Same(timeout, translated.InnerException);
+        Assert.IsNotAssignableFrom<OperationCanceledException>(translated);
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, true)]
+    public void ResolveMetadataProviderEnabled_CurrentConfigurationWinsOverTaskSnapshot(
+        bool taskValue,
+        bool currentValue,
+        bool expected)
+    {
+        var taskConfiguration = new PluginConfiguration { EnableMetadataProvider = taskValue };
+        var currentConfiguration = new PluginConfiguration { EnableMetadataProvider = currentValue };
+
+        Assert.Equal(
+            expected,
+            RefreshImdbRatingsTask.ResolveMetadataProviderEnabled(taskConfiguration, currentConfiguration));
+    }
+}


### PR DESCRIPTION
Newly scanned items currently wait until the next nightly run to get a rating. This adds a metadata provider that rates them during the scan itself, backed by a compact binary index the scheduled task writes.

## Why `ICustomMetadataProvider` and not `IRemoteMetadataProvider`

This is the load-bearing decision. The obvious implementation — a remote provider — cannot work, for two independent reasons:

**Ordering.** Jellyfin propagates newly discovered provider IDs to the lookup info only *after* each remote provider returns ([`MergeNewData`](https://github.com/jellyfin/jellyfin/blob/2c62d40f0d13926874eef9118a95be0dcee4e659/MediaBrowser.Providers/Manager/MetadataService.cs#L898-L954)), and merges community ratings first-non-null-wins:

```csharp
if (replaceData || !target.CommunityRating.HasValue)
{
    target.CommunityRating = source.CommunityRating;
}
```

So a remote provider ordered *before* TMDb has no IMDb ID yet for a normally identified new item, and one ordered *after* TMDb has the ID but finds its rating discarded. Those requirements are mutually exclusive. `IHasOrder` cannot resolve it — Jellyfin sorts by the library's configured `MetadataFetcherOrder` first, with `IHasOrder` only a secondary fallback.

**Enablement.** [`ProviderManager.CanRefreshMetadata`](https://github.com/jellyfin/jellyfin/blob/2c62d40f0d13926874eef9118a95be0dcee4e659/MediaBrowser.Providers/Manager/ProviderManager.cs#L462-L490) only consults the library's `MetadataFetchers` allowlist for remote providers:

```csharp
if (forceEnableInternetMetadata || provider is not IRemoteMetadataProvider)
{
    return true;
}
return _baseItemManager.IsMetadataFetcherEnabled(item, libraryTypeOptions, provider.Name);
```

A newly introduced fetcher name is absent from every existing library's saved list, and Jellyfin defaults unknown providers to disabled on new libraries — so a remote provider would build and load the index while never actually being called.

Custom providers run after the whole remote merge completes, receive the real item with IDs already propagated, and mutate it directly. Both problems disappear, and the plugin's own toggle becomes the single source of truth.

## Index format

Sorted `uint32` ids, ratings as a **single byte** (IMDb publishes exactly one decimal place — verified across all 1.7M rows), votes as `uint32` so the minimum-votes threshold stays a runtime setting rather than being baked in at build time.

One non-obvious detail: the IMDb flat file is byte-sorted, not numerically sorted — `tt10001002` precedes `tt9916850`. An explicit sort is required before binary search is valid.

Measured against the real file:

```
build   : 1,704,409 titles in ~360 ms
resident: 14.6 MB
load    : ~14 ms          (vs ~600 ms to reparse the TSV)
verify  : 1,704,409 rows checked, 0 mismatches
lookup  : ~35 ns each
```

The ~14 ms load is what keeps startup cheap. A disk-backed store (SQLite or similar) would buy the same property, but at 14.6 MB there is nothing to avoid holding in memory.

## Design constraints

- The scheduled task is the **sole writer**; the provider is a **pure reader** that never downloads. Scan-time lookups involve no network I/O, no concurrency gate, and no first-call latency.
- A fresh install has nothing to serve until the task first runs. Items are backfilled by the nightly run exactly as they are today.
- Scans only refresh **new or changed** items, so the provider does not re-walk an existing library — the scheduled task remains responsible for keeping existing ratings current as they drift.
- Seasons stay with the scheduled task — a season rating is the average of its episodes, which needs the whole season rather than a single item.
- Parsing is refactored so `BuildIndexAsync` reuses the existing TSV framing, header validation and per-field parsing instead of duplicating it. It validates *indexable* rows, so a well-formed file full of unusable IDs cannot overwrite a good index with an empty one.

On by default, with a settings toggle to disable.

## Testing

68 unit tests pass. Clean `Release` build with zero warnings, and both lint gates clean:

```
dotnet format whitespace --verify-no-changes
dotnet format style --verify-no-changes --severity warn
```

Unit coverage: index round-tripping, binary-search boundaries, the byte rating encoding, unsorted-input handling, corrupt/truncated/wrong-version index rejection, cache negative-caching and reload, and index-build validation.

### Verified on a live Jellyfin server

Tested against a running Jellyfin instance (Docker), end to end:

**Scheduled task** — completed in 4 seconds, reusing the cached TSV:

```
Parsed 27087 matching IMDb ratings from 1704409 valid rows in 1704409 rows (0 parse errors)
Indexed 1704409 IMDb ratings from 1704409 rows (0 parse errors, 0 unrepresentable IDs)
Wrote IMDb ratings index: 1704409 titles, 14.6 MB at /config/data/data/imdb-ratings-cache/title.ratings.idx
```

The index is `15,339,697` bytes on disk, exactly `16 + (1,704,409 × 9)` — header plus 4 B id, 1 B rating, 4 B votes per row.

**Provider invoked during a library scan** — the index loads on first lookup, not at startup:

```
Jellyfin.Plugin.ImdbRatings.Providers.ImdbRatingsItemProvider: Loaded IMDb ratings index: 1704409 titles, 14.6 MB resident
```

**Write path confirmed on a newly added movie.** TMDb reported `5.7` for the title; the cached IMDb snapshot had `6.2`; the item persisted as `6.2`. That is only reachable if the custom provider ran after TMDb and overwrote its value — which is exactly the sequence a remote provider could not achieve, since the first-non-null merge would have locked in TMDb's `5.7`.